### PR TITLE
After installing aoc-cli cargo download not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cargo scaffold <day>
 # Created empty input file "src/inputs/01.txt"
 # Created empty example file "src/examples/01.txt"
 # ---
-# 🎄 Type `cargo day 01` to run your solution.
+# 🎄 Type `cargo solve 01` to run your solution.
 ```
 
 Individual solutions live in the `./src/bin/` directory as separate binaries.

--- a/src/bin/download.rs
+++ b/src/bin/download.rs
@@ -56,20 +56,26 @@ fn main() {
         exit_with_status(1, &tmp_file_path);
     }
 
-    println!("Downloading input via aoc-cli...");
 
-    let mut cmd_args = vec![
-        "download".into(),
+    let mut tmp_cmd_args = vec![
         "--file".into(),
         tmp_file_path.to_string_lossy().to_string(),
         "--day".into(),
         args.day.to_string(),
+        "download".into(),
     ];
+
+    
+    let mut cmd_args = vec![];
 
     if let Some(year) = args.year {
         cmd_args.push("--year".into());
         cmd_args.push(year.to_string());
     }
+
+    cmd_args.append(&mut tmp_cmd_args);
+
+    println!("Downloading input with >aoc {}", cmd_args.join(" "));
 
     match Command::new("aoc").args(cmd_args).output() {
         Ok(cmd_output) => {


### PR DESCRIPTION
```
cargo download 01 --year 2021
   Compiling pico-args v0.5.0
   Compiling aoc v0.6.2 (/Users/peter/projects/sandbox/tmp/advent-of-code-rust)
    Finished dev [unoptimized + debuginfo] target(s) in 1.59s
     Running `target/debug/download 01 --year 2021`
Downloading input via aoc-cli...
error: Found argument '--file' which wasn't expected, or isn't valid in this context
```

Reading the [docs](https://github.com/scarvalhojr/aoc-cli/#usage) the options come before the command. 

This change puts the command after the options and for me now works?