### PR TITLE
fix: compatibility with aoc-cli@^0.4.0

### DIFF
--- a/src/bin/download.rs
+++ b/src/bin/download.rs
@@ -56,16 +56,6 @@ fn main() {
         exit_with_status(1, &tmp_file_path);
     }
 
-
-    let mut tmp_cmd_args = vec![
-        "--file".into(),
-        tmp_file_path.to_string_lossy().to_string(),
-        "--day".into(),
-        args.day.to_string(),
-        "download".into(),
-    ];
-
-    
     let mut cmd_args = vec![];
 
     if let Some(year) = args.year {
@@ -73,7 +63,13 @@ fn main() {
         cmd_args.push(year.to_string());
     }
 
-    cmd_args.append(&mut tmp_cmd_args);
+    cmd_args.append(&mut vec![
+        "--file".into(),
+        tmp_file_path.to_string_lossy().to_string(),
+        "--day".into(),
+        args.day.to_string(),
+        "download".into(),
+    ]);
 
     println!("Downloading input with >aoc {}", cmd_args.join(" "));
 

--- a/src/bin/download.rs
+++ b/src/bin/download.rs
@@ -56,20 +56,26 @@ fn main() {
         exit_with_status(1, &tmp_file_path);
     }
 
-    println!("Downloading input via aoc-cli...");
 
-    let mut cmd_args = vec![
-        "download".into(),
+    let mut tmp_cmd_args = vec![
         "--file".into(),
         tmp_file_path.to_string_lossy().to_string(),
         "--day".into(),
         args.day.to_string(),
+        "download".into(),
     ];
+
+    
+    let mut cmd_args = vec![];
 
     if let Some(year) = args.year {
         cmd_args.push("--year".into());
         cmd_args.push(year.to_string());
     }
+
+    cmd_args.append(&mut tmp_cmd_args);
+
+    println!("Downloading input with >aoc {}", cmd_args.join(" "));
 
     match Command::new("aoc").args(cmd_args).output() {
         Ok(cmd_output) => {


### PR DESCRIPTION
`aoc-cli` now enforces the argument order with [v0.4.0](https://github.com/scarvalhojr/aoc-cli/releases/tag/v0.4.0). This fixes the command invocation.

closes #6 