### PR TITLE
fix: rename package to `advent_of_code`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,11 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in executable 'aoc'",
+            "name": "Debug unit tests in executable 'advent_of_code'",
             "cargo": {
-                "args": ["test", "--no-run", "--bin=aoc", "--package=aoc"],
+                "args": ["test", "--no-run", "--bin=advent_of_code", "--package=advent_of_code"],
                 "filter": {
-                    "name": "aoc",
+                    "name": "advent_of_code",
                     "kind": "bin"
                 }
             },
@@ -21,11 +21,11 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'aoc'",
+            "name": "Debug executable 'advent_of_code'",
             "cargo": {
-                "args": ["build", "--bin=aoc", "--package=aoc"],
+                "args": ["build", "--bin=advent_of_code", "--package=advent_of_code"],
                 "filter": {
-                    "name": "aoc",
+                    "name": "advent_of_code",
                     "kind": "bin"
                 }
             },
@@ -35,11 +35,11 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in library 'aoc'",
+            "name": "Debug unit tests in library 'advent_of_code'",
             "cargo": {
-                "args": ["test", "--no-run", "--lib", "--package=aoc"],
+                "args": ["test", "--no-run", "--lib", "--package=advent_of_code"],
                 "filter": {
-                    "name": "aoc",
+                    "name": "advent_of_code",
                     "kind": "lib"
                 }
             },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 3
 
 [[package]]
-name = "aoc"
+name = "advent_of_code"
 version = "0.7.0"
 dependencies = [
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "aoc"
+name = "advent_of_code"
 version = "0.7.0"
 authors = ["Felix Spöttel <1682504+fspoettel@users.noreply.github.com>"]
 edition = "2021"
-default-run = "aoc"
+default-run = "advent_of_code"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Displayed _timings_ show the raw execution time of your solution without overhea
 cargo all
 
 # output:
-#     Running `target/release/aoc`
+#     Running `target/release/advent_of_code`
 # ----------
 # | Day 01 |
 # ----------

--- a/src/bin/scaffold.rs
+++ b/src/bin/scaffold.rs
@@ -17,9 +17,9 @@ pub fn part_two(input: &str) -> Option<u32> {
 }
 
 fn main() {
-    let input = &aoc::read_file("inputs", DAY);
-    aoc::solve!(1, part_one, input);
-    aoc::solve!(2, part_two, input);
+    let input = &advent_of_code::read_file("inputs", DAY);
+    advent_of_code::solve!(1, part_one, input);
+    advent_of_code::solve!(2, part_two, input);
 }
 
 #[cfg(test)]
@@ -28,13 +28,13 @@ mod tests {
 
     #[test]
     fn test_part_one() {
-        let input = aoc::read_file("examples", DAY);
+        let input = advent_of_code::read_file("examples", DAY);
         assert_eq!(part_one(&input), None);
     }
 
     #[test]
     fn test_part_two() {
-        let input = aoc::read_file("examples", DAY);
+        let input = advent_of_code::read_file("examples", DAY);
         assert_eq!(part_two(&input), None);
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
 /*
  * Use this file if you want to extract helpers from your solutions.
- * Example import from this file: `use aoc::helpers::example_fn;`.
+ * Example import from this file: `use advent_of_code::helpers::example_fn;`.
  */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub const ANSI_RESET: &str = "\x1b[0m";
 #[macro_export]
 macro_rules! solve {
     ($part:expr, $solver:ident, $input:expr) => {{
-        use aoc::{ANSI_BOLD, ANSI_ITALIC, ANSI_RESET};
+        use advent_of_code::{ANSI_BOLD, ANSI_ITALIC, ANSI_RESET};
         use std::fmt::Display;
         use std::time::Instant;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
  * This file contains template code.
  * There is no need to edit this file unless you want to change template functionality.
  */
-use aoc::{ANSI_BOLD, ANSI_ITALIC, ANSI_RESET};
+use advent_of_code::{ANSI_BOLD, ANSI_ITALIC, ANSI_RESET};
 use std::process::Command;
 
 fn main() {
@@ -34,7 +34,7 @@ fn main() {
             if is_empty {
                 0_f64
             } else {
-                aoc::parse_exec_time(&output)
+                advent_of_code::parse_exec_time(&output)
             }
         })
         .sum();


### PR DESCRIPTION
`aoc` shadowed the `aoc-cli` binary which could lead to issues.

closes #12