### PR TITLE
Update github CI actions/checkout@v2 to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
         runs-on: ubuntu-latest
         name: Check
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: cargo check
               run: cargo check
     test:
         runs-on: ubuntu-latest
         name: Test
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: cargo test
               run: cargo test
     # uncomment to enable clippy lints
@@ -25,6 +25,6 @@ jobs:
     #     runs-on: ubuntu-latest
     #     name: Lint (clippy)
     #     steps:
-    #         - uses: actions/checkout@v2
+    #         - uses: actions/checkout@v3
     #         - name: cargo clippy
     #           run: cargo clippy -- -D warnings

--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -10,7 +10,7 @@ jobs:
     update-readme:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               if: ${{ env.AOC_ENABLED }}
               env:
                   AOC_ENABLED: ${{ secrets.AOC_ENABLED }}


### PR DESCRIPTION
Github actions using Node.js 12 are deprecated. V3 uses Node 16 instead. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/