### PR TITLE
Add CI hook to check code formating using "cargo fmt --check"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,11 @@ jobs:
     #         - uses: actions/checkout@v2
     #         - name: cargo clippy
     #           run: cargo clippy -- -D warnings
+    # uncoment to enable format checking
+    # fmt:
+    #     runs-on: ubuntu-latest
+    #     name: Format
+    #     steps:
+    #         - uses: actions/checkout@v3
+    #         - name: cargo fmt
+    #           run: cargo fmt --check

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ cargo clippy
 
 Once installed, you can use the [download command](#download-input-for-a-day).
 
+### Enable Format code in CI
+
+Uncomment the `format` job in the `ci.yml` workflow to enable fmt checks in CI.
+
 ### Enable clippy lints in CI
 
 Uncomment the `clippy` job in the `ci.yml` workflow to enable clippy checks in CI.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ cargo clippy
 
 Once installed, you can use the [download command](#download-input-for-a-day).
 
-### Enable Format code in CI
+### Check code formatting in CI
 
 Uncomment the `format` job in the `ci.yml` workflow to enable fmt checks in CI.
 


### PR DESCRIPTION
Not sure this is something that is actually needed but I personally like to use format checking in CI, even though I use format on save in my editor. 

Normally I would create an issue first to discuss adding something like this, but since it was such a simple change I though I just create a PR.