### PR TITLE
feat: download puzzle descriptions

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,7 @@
 [alias]
-scaffold = "run --bin scaffold -- "
-download = "run --bin download -- "
+scaffold = "run --bin scaffold --quiet --release -- "
+download = "run --bin download --quiet --release -- "
+read = "run --bin read --quiet --release -- "
 
 solve = "run --bin"
 all = "run"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Every [solution](https://github.com/fspoettel/advent-of-code-rust/blob/main/src/
 
 When editing a solution, `rust-analyzer` will display buttons for running / debugging unit tests above the unit test blocks.
 
-### Download input for a day
+### Download input & description for a day
 
 > **Note**  
 > This command requires [installing the aoc-cli crate](#download-puzzle-inputs-via-aoc-cli).
@@ -60,18 +60,20 @@ When editing a solution, `rust-analyzer` will display buttons for running / debu
 cargo download <day>
 
 # output:
-# Downloading input with aoc-cli...
-# Loaded session cookie from "/home/felix/.adventofcode.session".
-# Downloading input for day 1, 2021...
-# Saving puzzle input to "/tmp/tmp.MBdcAdL9Iw/input"...
+# Loaded session cookie from "/Users/<snip>/.adventofcode.session".
+# Fetching puzzle for day 1, 2022...
+# Saving puzzle description to "src/puzzles/01.md"...
+# Downloading input for day 1, 2022...
+# Saving puzzle input to "src/inputs/01.txt"...
 # Done!
 # ---
-# 🎄 Successfully wrote input to "src/inputs/01.txt"!
+# 🎄 Successfully wrote input to "src/inputs/01.txt".
+# 🎄 Successfully wrote puzzle to "src/puzzles/01.md".
 ```
 
 To download inputs for previous years, append the `--year/-y` flag. _(example: `cargo download 1 --year 2020`)_
 
-Puzzle inputs are not checked into git. [Reasoning](https://old.reddit.com/r/adventofcode/comments/k99rod/sharing_input_data_were_we_requested_not_to/gf2ukkf/?context=3).
+Puzzle descriptions are stored in `src/puzzles` as markdown files. Puzzle inputs are not checked into git. [Reasoning](https://old.reddit.com/r/adventofcode/comments/k99rod/sharing_input_data_were_we_requested_not_to/gf2ukkf/?context=3).
 
 ### Run solutions for a day
 
@@ -139,11 +141,28 @@ cargo fmt
 cargo clippy
 ```
 
+### Read puzzle description in terminal
+
+> **Note**  
+> This command requires [installing the aoc-cli crate](#download-puzzle-inputs-via-aoc-cli).
+
+```sh
+# example: `cargo read 1`
+cargo read <day>
+
+# output:
+# Loaded session cookie from "/Users/<snip>/.adventofcode.session".
+# Fetching puzzle for day 1, 2022...
+# ...the input...
+```
+
+To read inputs for previous years, append the `--year/-y` flag. _(example: `cargo read 1 --year 2020`)_
+
 ## Optional template features
 
 ### Download puzzle inputs via aoc-cli
 
-1. Install [`aoc-cli`](https://github.com/scarvalhojr/aoc-cli/) via cargo: `cargo install aoc-cli --version 0.5.0`.
+1. Install [`aoc-cli`](https://github.com/scarvalhojr/aoc-cli/) via cargo: `cargo install aoc-cli --version 0.6
 2. Create an `.adventofcode.session` file in your home directory and paste your session cookie[^1] into it. To get this, press F12 anywhere on the Advent of Code website to open your browser developer tools. Look in your Cookies under the Application or Storage tab, and copy out the `session` cookie value.
 
 Once installed, you can use the [download command](#download-input-for-a-day).

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ To read inputs for previous years, append the `--year/-y` flag. _(example: `carg
 
 ### Download puzzle inputs via aoc-cli
 
-1. Install [`aoc-cli`](https://github.com/scarvalhojr/aoc-cli/) via cargo: `cargo install aoc-cli --version 0.6.0
+1. Install [`aoc-cli`](https://github.com/scarvalhojr/aoc-cli/) via cargo: `cargo install aoc-cli --version 0.7.0`
 2. Create an `.adventofcode.session` file in your home directory and paste your session cookie[^1] into it. To get this, press F12 anywhere on the Advent of Code website to open your browser developer tools. Look in your Cookies under the Application or Storage tab, and copy out the `session` cookie value.
 
 Once installed, you can use the [download command](#download-input-for-a-day).

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ To read inputs for previous years, append the `--year/-y` flag. _(example: `carg
 
 ### Download puzzle inputs via aoc-cli
 
-1. Install [`aoc-cli`](https://github.com/scarvalhojr/aoc-cli/) via cargo: `cargo install aoc-cli --version 0.6
+1. Install [`aoc-cli`](https://github.com/scarvalhojr/aoc-cli/) via cargo: `cargo install aoc-cli --version 0.6.0
 2. Create an `.adventofcode.session` file in your home directory and paste your session cookie[^1] into it. To get this, press F12 anywhere on the Advent of Code website to open your browser developer tools. Look in your Cookies under the Application or Storage tab, and copy out the `session` cookie value.
 
 Once installed, you can use the [download command](#download-input-for-a-day).

--- a/src/bin/read.rs
+++ b/src/bin/read.rs
@@ -32,7 +32,7 @@ fn main() {
         process::exit(1);
     }
 
-    match aoc_cli::download(args.day, args.year) {
+    match aoc_cli::read(args.day, args.year) {
         Ok(cmd_output) => {
             if !cmd_output.status.success() {
                 process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,3 +123,104 @@ mod tests {
         );
     }
 }
+
+pub mod aoc_cli {
+    use std::{
+        fmt::Display,
+        fs::create_dir_all,
+        process::{Command, Output, Stdio},
+    };
+
+    pub enum AocCliError {
+        CommandNotFound,
+        CommandFailed,
+        IoError,
+    }
+
+    impl Display for AocCliError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                AocCliError::CommandNotFound => write!(f, "CommandNotFound"),
+                AocCliError::CommandFailed => write!(f, "CommandFailed"),
+                AocCliError::IoError => write!(f, "IoError"),
+            }
+        }
+    }
+
+    pub fn check() -> Result<(), AocCliError> {
+        Command::new("aoc")
+            .arg("-V")
+            .output()
+            .map_err(|_| AocCliError::CommandNotFound)?;
+        Ok(())
+    }
+
+    pub fn read(day: u8, year: Option<u16>) -> Result<Output, AocCliError> {
+        // TODO: output local puzzle if present.
+        let args = build_args("read", &[], day, year);
+        call_aoc_cli(&args)
+    }
+
+    pub fn download(day: u8, year: Option<u16>) -> Result<Output, AocCliError> {
+        let input_path = get_input_path(day);
+
+        let puzzle_path = get_puzzle_path(day);
+        create_dir_all("src/puzzles").map_err(|_| AocCliError::IoError)?;
+
+        let args = build_args(
+            "download",
+            &[
+                "--overwrite".into(),
+                "--input-file".into(),
+                input_path.to_string(),
+                "--puzzle-file".into(),
+                puzzle_path.to_string(),
+            ],
+            day,
+            year,
+        );
+
+        let output = call_aoc_cli(&args)?;
+        println!("---");
+        println!("🎄 Successfully wrote input to \"{}\".", &input_path);
+        println!("🎄 Successfully wrote puzzle to \"{}\".", &puzzle_path);
+
+        Ok(output)
+    }
+
+    fn get_input_path(day: u8) -> String {
+        let day_padded = format!("{:02}", day);
+        format!("src/inputs/{}.txt", day_padded)
+    }
+
+    fn get_puzzle_path(day: u8) -> String {
+        let day_padded = format!("{:02}", day);
+        format!("src/puzzles/{}.md", day_padded)
+    }
+
+    fn build_args(command: &str, args: &[String], day: u8, year: Option<u16>) -> Vec<String> {
+        let mut cmd_args = args.to_vec();
+
+        if let Some(year) = year {
+            cmd_args.push("--year".into());
+            cmd_args.push(year.to_string());
+        }
+
+        cmd_args.append(&mut vec!["--day".into(), day.to_string(), command.into()]);
+
+        cmd_args
+    }
+
+    fn call_aoc_cli(args: &[String]) -> Result<Output, AocCliError> {
+        if cfg!(debug_assertions) {
+            println!("Calling >aoc with: {}", args.join(" "));
+        }
+
+        Command::new("aoc")
+            .args(args)
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .output()
+            .map_err(|_| AocCliError::CommandFailed)
+    }
+}


### PR DESCRIPTION
* add support for downloading puzzle descriptions in `cargo download`
* add `cargo read` command to read puzzles in terminal
* extract `aoc_cli` module
* use `aoc-cli`'s new overwrite option to remove tmp file logic
* avoid cargo output when running aliases commands
* move aoc debug code behind debug flag

TODO:
- [x] test on windows