### PR TITLE
Make the template pass cargo clippy by resolving warnings

### DIFF
--- a/src/bin/download.rs
+++ b/src/bin/download.rs
@@ -22,7 +22,7 @@ fn main() {
     let args = match parse_args() {
         Ok(args) => args,
         Err(e) => {
-            eprintln!("Failed to process arguments: {}", e);
+            eprintln!("Failed to process arguments: {e}");
             process::exit(1);
         }
     };
@@ -39,7 +39,7 @@ fn main() {
             }
         }
         Err(e) => {
-            eprintln!("failed to spawn aoc-cli: {}", e);
+            eprintln!("failed to spawn aoc-cli: {e}");
             process::exit(1);
         }
     }

--- a/src/bin/read.rs
+++ b/src/bin/read.rs
@@ -22,7 +22,7 @@ fn main() {
     let args = match parse_args() {
         Ok(args) => args,
         Err(e) => {
-            eprintln!("Failed to process arguments: {}", e);
+            eprintln!("Failed to process arguments: {e}");
             process::exit(1);
         }
     };
@@ -39,7 +39,7 @@ fn main() {
             }
         }
         Err(e) => {
-            eprintln!("failed to spawn aoc-cli: {}", e);
+            eprintln!("failed to spawn aoc-cli: {e}");
             process::exit(1);
         }
     }

--- a/src/bin/scaffold.rs
+++ b/src/bin/scaffold.rs
@@ -62,16 +62,16 @@ fn main() {
         }
     };
 
-    let day_padded = format!("{:02}", day);
+    let day_padded = format!("{day:02}");
 
-    let input_path = format!("src/inputs/{}.txt", day_padded);
-    let example_path = format!("src/examples/{}.txt", day_padded);
-    let module_path = format!("src/bin/{}.rs", day_padded);
+    let input_path = format!("src/inputs/{day_padded}.txt");
+    let example_path = format!("src/examples/{day_padded}.txt");
+    let module_path = format!("src/bin/{day_padded}.rs");
 
     let mut file = match safe_create_file(&module_path) {
         Ok(file) => file,
         Err(e) => {
-            eprintln!("Failed to create module file: {}", e);
+            eprintln!("Failed to create module file: {e}");
             process::exit(1);
         }
     };
@@ -81,7 +81,7 @@ fn main() {
             println!("Created module file \"{}\"", &module_path);
         }
         Err(e) => {
-            eprintln!("Failed to write module contents: {}", e);
+            eprintln!("Failed to write module contents: {e}");
             process::exit(1);
         }
     }
@@ -91,7 +91,7 @@ fn main() {
             println!("Created empty input file \"{}\"", &input_path);
         }
         Err(e) => {
-            eprintln!("Failed to create input file: {}", e);
+            eprintln!("Failed to create input file: {e}");
             process::exit(1);
         }
     }
@@ -101,7 +101,7 @@ fn main() {
             println!("Created empty example file \"{}\"", &example_path);
         }
         Err(e) => {
-            eprintln!("Failed to create example file: {}", e);
+            eprintln!("Failed to create example file: {e}");
             process::exit(1);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ macro_rules! solve {
 pub fn read_file(folder: &str, day: u8) -> String {
     let cwd = env::current_dir().unwrap();
 
-    let filepath = cwd.join("src").join(folder).join(format!("{:02}.txt", day));
+    let filepath = cwd.join("src").join(folder).join(format!("{day:02}.txt"));
 
     let f = fs::read_to_string(filepath);
     f.expect("could not open input file")
@@ -197,13 +197,13 @@ pub mod aoc_cli {
     }
 
     fn get_input_path(day: u8) -> String {
-        let day_padded = format!("{:02}", day);
-        format!("src/inputs/{}.txt", day_padded)
+        let day_padded = format!("{day:02}");
+        format!("src/inputs/{day_padded}.txt")
     }
 
     fn get_puzzle_path(day: u8) -> String {
-        let day_padded = format!("{:02}", day);
-        format!("src/puzzles/{}.md", day_padded)
+        let day_padded = format!("{day:02}");
+        format!("src/puzzles/{day_padded}.md")
     }
 
     fn build_args(command: &str, args: &[String], day: u8, year: Option<u16>) -> Vec<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,5 @@ fn main() {
         })
         .sum();
 
-    println!(
-        "{ANSI_BOLD}Total:{ANSI_RESET} {ANSI_ITALIC}{total:.2}ms{ANSI_RESET}"
-    );
+    println!("{ANSI_BOLD}Total:{ANSI_RESET} {ANSI_ITALIC}{total:.2}ms{ANSI_RESET}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn main() {
     let total: f64 = (1..=25)
         .map(|day| {
-            let day = format!("{:02}", day);
+            let day = format!("{day:02}");
 
             let mut args = vec!["run", "--bin", &day];
             if cfg!(not(debug_assertions)) {
@@ -18,7 +18,7 @@ fn main() {
             let cmd = Command::new("cargo").args(&args).output().unwrap();
 
             println!("----------");
-            println!("{}| Day {} |{}", ANSI_BOLD, day, ANSI_RESET);
+            println!("{ANSI_BOLD}| Day {day} |{ANSI_RESET}");
             println!("----------");
 
             let output = String::from_utf8(cmd.stdout).unwrap();
@@ -42,7 +42,6 @@ fn main() {
         .sum();
 
     println!(
-        "{}Total:{} {}{:.2}ms{}",
-        ANSI_BOLD, ANSI_RESET, ANSI_ITALIC, total, ANSI_RESET
+        "{ANSI_BOLD}Total:{ANSI_RESET} {ANSI_ITALIC}{total:.2}ms{ANSI_RESET}"
     );
 }


### PR DESCRIPTION
Resolve the `cargo clippy` warnings in the template so that new projects created from the template will only show warnings on code added by the user.

All of the errors are [`clippy::uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)