### PR TITLE
Resolve the majority of pedantic clippy warnings

### DIFF
--- a/src/bin/download.rs
+++ b/src/bin/download.rs
@@ -22,7 +22,7 @@ fn main() {
     let args = match parse_args() {
         Ok(args) => args,
         Err(e) => {
-            eprintln!("Failed to process arguments: {}", e);
+            eprintln!("Failed to process arguments: {e}");
             process::exit(1);
         }
     };
@@ -39,7 +39,7 @@ fn main() {
             }
         }
         Err(e) => {
-            eprintln!("failed to spawn aoc-cli: {}", e);
+            eprintln!("failed to spawn aoc-cli: {e}");
             process::exit(1);
         }
     }

--- a/src/bin/read.rs
+++ b/src/bin/read.rs
@@ -22,7 +22,7 @@ fn main() {
     let args = match parse_args() {
         Ok(args) => args,
         Err(e) => {
-            eprintln!("Failed to process arguments: {}", e);
+            eprintln!("Failed to process arguments: {e}");
             process::exit(1);
         }
     };
@@ -39,7 +39,7 @@ fn main() {
             }
         }
         Err(e) => {
-            eprintln!("failed to spawn aoc-cli: {}", e);
+            eprintln!("failed to spawn aoc-cli: {e}");
             process::exit(1);
         }
     }

--- a/src/bin/scaffold.rs
+++ b/src/bin/scaffold.rs
@@ -62,16 +62,16 @@ fn main() {
         }
     };
 
-    let day_padded = format!("{:02}", day);
+    let day_padded = format!("{day:02}");
 
-    let input_path = format!("src/inputs/{}.txt", day_padded);
-    let example_path = format!("src/examples/{}.txt", day_padded);
-    let module_path = format!("src/bin/{}.rs", day_padded);
+    let input_path = format!("src/inputs/{day_padded}.txt");
+    let example_path = format!("src/examples/{day_padded}.txt");
+    let module_path = format!("src/bin/{day_padded}.rs");
 
     let mut file = match safe_create_file(&module_path) {
         Ok(file) => file,
         Err(e) => {
-            eprintln!("Failed to create module file: {}", e);
+            eprintln!("Failed to create module file: {e}");
             process::exit(1);
         }
     };
@@ -81,7 +81,7 @@ fn main() {
             println!("Created module file \"{}\"", &module_path);
         }
         Err(e) => {
-            eprintln!("Failed to write module contents: {}", e);
+            eprintln!("Failed to write module contents: {e}");
             process::exit(1);
         }
     }
@@ -91,7 +91,7 @@ fn main() {
             println!("Created empty input file \"{}\"", &input_path);
         }
         Err(e) => {
-            eprintln!("Failed to create input file: {}", e);
+            eprintln!("Failed to create input file: {e}");
             process::exit(1);
         }
     }
@@ -101,7 +101,7 @@ fn main() {
             println!("Created empty example file \"{}\"", &example_path);
         }
         Err(e) => {
-            eprintln!("Failed to create example file: {}", e);
+            eprintln!("Failed to create example file: {e}");
             process::exit(1);
         }
     }

--- a/src/bin/scaffold.rs
+++ b/src/bin/scaffold.rs
@@ -8,10 +8,12 @@ use std::{
     process,
 };
 
-const MODULE_TEMPLATE: &str = r###"pub fn part_one(input: &str) -> Option<u32> {
+const MODULE_TEMPLATE: &str = r###"#[must_use]
+pub fn part_one(input: &str) -> Option<u32> {
     None
 }
 
+#[must_use]
 pub fn part_two(input: &str) -> Option<u32> {
     None
 }

--- a/src/bin/scaffold.rs
+++ b/src/bin/scaffold.rs
@@ -54,12 +54,9 @@ fn create_file(path: &str) -> Result<File, std::io::Error> {
 }
 
 fn main() {
-    let day = match parse_args() {
-        Ok(day) => day,
-        Err(_) => {
-            eprintln!("Need to specify a day (as integer). example: `cargo scaffold 7`");
-            process::exit(1);
-        }
+    let Ok(day) = parse_args() else {
+        eprintln!("Need to specify a day (as integer). example: `cargo scaffold 7`");
+        process::exit(1);
     };
 
     let day_padded = format!("{day:02}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ macro_rules! solve {
 pub fn read_file(folder: &str, day: u8) -> String {
     let cwd = env::current_dir().unwrap();
 
-    let filepath = cwd.join("src").join(folder).join(format!("{:02}.txt", day));
+    let filepath = cwd.join("src").join(folder).join(format!("{day:02}.txt"));
 
     let f = fs::read_to_string(filepath);
     f.expect("could not open input file")
@@ -197,13 +197,13 @@ pub mod aoc_cli {
     }
 
     fn get_input_path(day: u8) -> String {
-        let day_padded = format!("{:02}", day);
-        format!("src/inputs/{}.txt", day_padded)
+        let day_padded = format!("{day:02}");
+        format!("src/inputs/{day_padded}.txt")
     }
 
     fn get_puzzle_path(day: u8) -> String {
-        let day_padded = format!("{:02}", day);
-        format!("src/puzzles/{}.md", day_padded)
+        let day_padded = format!("{day:02}");
+        format!("src/puzzles/{day_padded}.md")
     }
 
     fn build_args(command: &str, args: &[String], day: u8, year: Option<u16>) -> Vec<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,45 +133,45 @@ pub mod aoc_cli {
         process::{Command, Output, Stdio},
     };
 
-    pub enum AocCliError {
+    pub enum CliError {
         CommandNotFound,
         CommandNotCallable,
         BadExitStatus(Output),
         IoError,
     }
 
-    impl Display for AocCliError {
+    impl Display for CliError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self {
-                AocCliError::CommandNotFound => write!(f, "aoc-cli is not present in environment."),
-                AocCliError::CommandNotCallable => write!(f, "aoc-cli could not be called."),
-                AocCliError::BadExitStatus(_) => {
+                CliError::CommandNotFound => write!(f, "aoc-cli is not present in environment."),
+                CliError::CommandNotCallable => write!(f, "aoc-cli could not be called."),
+                CliError::BadExitStatus(_) => {
                     write!(f, "aoc-cli exited with a non-zero status.")
                 }
-                AocCliError::IoError => write!(f, "could not write output files to file system."),
+                CliError::IoError => write!(f, "could not write output files to file system."),
             }
         }
     }
 
-    pub fn check() -> Result<(), AocCliError> {
+    pub fn check() -> Result<(), CliError> {
         Command::new("aoc")
             .arg("-V")
             .output()
-            .map_err(|_| AocCliError::CommandNotFound)?;
+            .map_err(|_| CliError::CommandNotFound)?;
         Ok(())
     }
 
-    pub fn read(day: u8, year: Option<u16>) -> Result<Output, AocCliError> {
+    pub fn read(day: u8, year: Option<u16>) -> Result<Output, CliError> {
         // TODO: output local puzzle if present.
         let args = build_args("read", &[], day, year);
         call_aoc_cli(&args)
     }
 
-    pub fn download(day: u8, year: Option<u16>) -> Result<Output, AocCliError> {
+    pub fn download(day: u8, year: Option<u16>) -> Result<Output, CliError> {
         let input_path = get_input_path(day);
 
         let puzzle_path = get_puzzle_path(day);
-        create_dir_all("src/puzzles").map_err(|_| AocCliError::IoError)?;
+        create_dir_all("src/puzzles").map_err(|_| CliError::IoError)?;
 
         let args = build_args(
             "download",
@@ -194,7 +194,7 @@ pub mod aoc_cli {
             println!("🎄 Successfully wrote puzzle to \"{}\".", &puzzle_path);
             Ok(output)
         } else {
-            Err(AocCliError::BadExitStatus(output))
+            Err(CliError::BadExitStatus(output))
         }
     }
 
@@ -221,7 +221,7 @@ pub mod aoc_cli {
         cmd_args
     }
 
-    fn call_aoc_cli(args: &[String]) -> Result<Output, AocCliError> {
+    fn call_aoc_cli(args: &[String]) -> Result<Output, CliError> {
         if cfg!(debug_assertions) {
             println!("Calling >aoc with: {}", args.join(" "));
         }
@@ -231,6 +231,6 @@ pub mod aoc_cli {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .output()
-            .map_err(|_| AocCliError::CommandNotCallable)
+            .map_err(|_| CliError::CommandNotCallable)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,7 @@ fn parse_time(val: &str, postfix: &str) -> f64 {
 
 pub fn parse_exec_time(output: &str) -> f64 {
     output.lines().fold(0_f64, |acc, l| {
-        if !l.contains("elapsed:") {
-            acc
-        } else {
+        if l.contains("elapsed:") {
             let timing = l.split("(elapsed: ").last().unwrap();
             // use `contains` istd. of `ends_with`: string may contain ANSI escape sequences.
             // for possible time formats, see: https://github.com/rust-lang/rust/blob/1.64.0/library/core/src/time.rs#L1176-L1200
@@ -73,6 +71,8 @@ pub fn parse_exec_time(output: &str) -> f64 {
             } else {
                 acc
             }
+        } else {
+            acc
         }
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ macro_rules! solve {
     }};
 }
 
+#[must_use]
 pub fn read_file(folder: &str, day: u8) -> String {
     let cwd = env::current_dir().unwrap();
 
@@ -54,6 +55,7 @@ fn parse_time(val: &str, postfix: &str) -> f64 {
     val.split(postfix).next().unwrap().parse().unwrap()
 }
 
+#[must_use]
 pub fn parse_exec_time(output: &str) -> f64 {
     output.lines().fold(0_f64, |acc, l| {
         if l.contains("elapsed:") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,5 @@ fn main() {
         })
         .sum();
 
-    println!(
-        "{ANSI_BOLD}Total:{ANSI_RESET} {ANSI_ITALIC}{total:.2}ms{ANSI_RESET}"
-    );
+    println!("{ANSI_BOLD}Total:{ANSI_RESET} {ANSI_ITALIC}{total:.2}ms{ANSI_RESET}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn main() {
     let total: f64 = (1..=25)
         .map(|day| {
-            let day = format!("{:02}", day);
+            let day = format!("{day:02}");
 
             let mut args = vec!["run", "--bin", &day];
             if cfg!(not(debug_assertions)) {
@@ -18,7 +18,7 @@ fn main() {
             let cmd = Command::new("cargo").args(&args).output().unwrap();
 
             println!("----------");
-            println!("{}| Day {} |{}", ANSI_BOLD, day, ANSI_RESET);
+            println!("{ANSI_BOLD}| Day {day} |{ANSI_RESET}");
             println!("----------");
 
             let output = String::from_utf8(cmd.stdout).unwrap();
@@ -42,7 +42,6 @@ fn main() {
         .sum();
 
     println!(
-        "{}Total:{} {}{:.2}ms{}",
-        ANSI_BOLD, ANSI_RESET, ANSI_ITALIC, total, ANSI_RESET
+        "{ANSI_BOLD}Total:{ANSI_RESET} {ANSI_ITALIC}{total:.2}ms{ANSI_RESET}"
     );
 }


### PR DESCRIPTION
Resolve most warnings shown by `cargo clippy -- -W clippy::pedantic`:
- clippy::single_match_else
- clippy::if_not_else
- clippy::must_use_candidate
- clippy::module_name_repetitions

This leaves only the Panics/Errors documentation warnings as discussed in #28 