### PR TITLE
Add a Day type to provide better handling of day value

### DIFF
--- a/src/day.rs
+++ b/src/day.rs
@@ -106,3 +106,42 @@ impl Iterator for EveryDay {
 }
 
 /* -------------------------------------------------------------------------- */
+
+#[cfg(feature = "test_lib")]
+mod tests {
+    use super::{every_day, Day};
+
+    #[test]
+    fn every_day_iterator() {
+        let mut iter = every_day();
+
+        assert_eq!(iter.next(), Some(Day::new_unchecked(1)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(2)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(3)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(4)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(5)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(6)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(7)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(8)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(9)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(10)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(11)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(12)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(13)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(14)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(15)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(16)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(17)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(18)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(19)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(20)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(21)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(22)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(23)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(24)));
+        assert_eq!(iter.next(), Some(Day::new_unchecked(25)));
+        assert_eq!(iter.next(), None);
+    }
+}
+
+/* -------------------------------------------------------------------------- */

--- a/src/day.rs
+++ b/src/day.rs
@@ -1,0 +1,100 @@
+use std::error::Error;
+use std::fmt::Display;
+use std::str::FromStr;
+
+/* -------------------------------------------------------------------------- */
+
+/// A valid day number of advent (i.e. an integer in range 1 to 25).
+///
+/// # Display
+/// This value is display as a two digit number.
+///
+/// ```
+/// let day = Day::new(8).unwrap();
+/// assert_eq!(day.to_string(), "08")
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Day(u8);
+
+impl Day {
+    pub fn new(day: u8) -> Option<Self> {
+        if day == 0 || day > 25 {
+            return None;
+        }
+        Some(Self(day))
+    }
+
+    fn new_unchecked(day: u8) -> Self {
+        debug_assert!(day != 0 && day <= 25);
+        Self(day)
+    }
+}
+
+impl Display for Day {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:02}", self.0)
+    }
+}
+
+impl PartialEq<u8> for Day {
+    fn eq(&self, other: &u8) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<u8> for Day {
+    fn partial_cmp(&self, other: &u8) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+
+impl FromStr for Day {
+    type Err = DayFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let day = s.parse().map_err(|_| DayFromStrError)?;
+        Self::new(day).ok_or(DayFromStrError)
+    }
+}
+
+#[derive(Debug)]
+pub struct DayFromStrError;
+
+impl Error for DayFromStrError {}
+
+impl Display for DayFromStrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("expecting a number between 1 and 25")
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/// An iterator that yield every day of advent from the 1st to the 25th.
+pub fn every_day() -> EveryDay {
+    EveryDay { current: 1 }
+}
+
+/// An iterator that yield every day of advent from the 1st to the 25th.
+pub struct EveryDay {
+    current: u8,
+}
+
+impl Iterator for EveryDay {
+    type Item = Day;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current > 25 {
+            return None;
+        }
+        // NOTE: the iterator start at 1 and we have verified that the value is not above 25.
+        let day = Day::new_unchecked(self.current);
+        self.current += 1;
+
+        Some(day)
+    }
+}
+
+/* -------------------------------------------------------------------------- */

--- a/src/day.rs
+++ b/src/day.rs
@@ -74,7 +74,7 @@ impl Error for DayFromStrError {}
 
 impl Display for DayFromStrError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("expecting a number between 1 and 25")
+        f.write_str("expecting a day number between 1 and 25")
     }
 }
 

--- a/src/day.rs
+++ b/src/day.rs
@@ -17,6 +17,8 @@ use std::str::FromStr;
 pub struct Day(u8);
 
 impl Day {
+    /// Creates a [`Day`] from the provided value if it's in the valid range,
+    /// returns [`None`] otherwise.
     pub fn new(day: u8) -> Option<Self> {
         if day == 0 || day > 25 {
             return None;
@@ -29,6 +31,7 @@ impl Day {
         Self(day)
     }
 
+    /// Converts the [`Day`] into an [`u8`].
     pub fn into_inner(self) -> u8 {
         self.0
     }
@@ -63,6 +66,7 @@ impl FromStr for Day {
     }
 }
 
+/// An error which can be returned when parsing a [`Day`].
 #[derive(Debug)]
 pub struct DayFromStrError;
 

--- a/src/day.rs
+++ b/src/day.rs
@@ -28,6 +28,10 @@ impl Day {
         debug_assert!(day != 0 && day <= 25);
         Self(day)
     }
+
+    pub fn into_inner(self) -> u8 {
+        self.0
+    }
 }
 
 impl Display for Day {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
+mod day;
 pub mod template;
+
+pub use day::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,20 @@ use args::{parse, AppArguments};
 mod args {
     use std::process;
 
+    use advent_of_code::Day;
+
     pub enum AppArguments {
         Download {
-            day: u8,
+            day: Day,
         },
         Read {
-            day: u8,
+            day: Day,
         },
         Scaffold {
-            day: u8,
+            day: Day,
         },
         Solve {
-            day: u8,
+            day: Day,
             release: bool,
             time: bool,
             submit: Option<u8>,

--- a/src/template/aoc_cli.rs
+++ b/src/template/aoc_cli.rs
@@ -4,6 +4,8 @@ use std::{
     process::{Command, Output, Stdio},
 };
 
+use crate::Day;
+
 #[derive(Debug)]
 pub enum AocCommandError {
     CommandNotFound,
@@ -33,7 +35,7 @@ pub fn check() -> Result<(), AocCommandError> {
     Ok(())
 }
 
-pub fn read(day: u8) -> Result<Output, AocCommandError> {
+pub fn read(day: Day) -> Result<Output, AocCommandError> {
     let puzzle_path = get_puzzle_path(day);
 
     let args = build_args(
@@ -49,7 +51,7 @@ pub fn read(day: u8) -> Result<Output, AocCommandError> {
     call_aoc_cli(&args)
 }
 
-pub fn download(day: u8) -> Result<Output, AocCommandError> {
+pub fn download(day: Day) -> Result<Output, AocCommandError> {
     let input_path = get_input_path(day);
     let puzzle_path = get_puzzle_path(day);
 
@@ -72,7 +74,7 @@ pub fn download(day: u8) -> Result<Output, AocCommandError> {
     Ok(output)
 }
 
-pub fn submit(day: u8, part: u8, result: &str) -> Result<Output, AocCommandError> {
+pub fn submit(day: Day, part: u8, result: &str) -> Result<Output, AocCommandError> {
     // workaround: the argument order is inverted for submit.
     let mut args = build_args("submit", &[], day);
     args.push(part.to_string());
@@ -80,14 +82,12 @@ pub fn submit(day: u8, part: u8, result: &str) -> Result<Output, AocCommandError
     call_aoc_cli(&args)
 }
 
-fn get_input_path(day: u8) -> String {
-    let day_padded = format!("{day:02}");
-    format!("data/inputs/{day_padded}.txt")
+fn get_input_path(day: Day) -> String {
+    format!("data/inputs/{day}.txt")
 }
 
-fn get_puzzle_path(day: u8) -> String {
-    let day_padded = format!("{day:02}");
-    format!("data/puzzles/{day_padded}.md")
+fn get_puzzle_path(day: Day) -> String {
+    format!("data/puzzles/{day}.md")
 }
 
 fn get_year() -> Option<u16> {
@@ -97,7 +97,7 @@ fn get_year() -> Option<u16> {
     }
 }
 
-fn build_args(command: &str, args: &[String], day: u8) -> Vec<String> {
+fn build_args(command: &str, args: &[String], day: Day) -> Vec<String> {
     let mut cmd_args = args.to_vec();
 
     if let Some(year) = get_year() {

--- a/src/template/commands/all.rs
+++ b/src/template/commands/all.rs
@@ -204,6 +204,8 @@ mod child_commands {
     mod tests {
         use super::parse_exec_time;
 
+        use crate::Day;
+
         #[test]
         fn test_well_formed() {
             let res = parse_exec_time(
@@ -212,7 +214,7 @@ mod child_commands {
                     "Part 2: 10 (74.13ms @ 99999 samples)".into(),
                     "".into(),
                 ],
-                1,
+                Day::new(1).unwrap(),
             );
             assert_approx_eq!(res.total_nanos, 74130074.13_f64);
             assert_eq!(res.part_1.unwrap(), "74.13ns");
@@ -227,7 +229,7 @@ mod child_commands {
                     "Part 2: 10s (100ms @ 1 samples)".into(),
                     "".into(),
                 ],
-                1,
+                Day::new(1).unwrap(),
             );
             assert_approx_eq!(res.total_nanos, 2100000000_f64);
             assert_eq!(res.part_1.unwrap(), "2s");
@@ -242,7 +244,7 @@ mod child_commands {
                     "Part 2: ✖        ".into(),
                     "".into(),
                 ],
-                1,
+                Day::new(1).unwrap(),
             );
             assert_approx_eq!(res.total_nanos, 0_f64);
             assert_eq!(res.part_1.is_none(), true);

--- a/src/template/commands/all.rs
+++ b/src/template/commands/all.rs
@@ -4,11 +4,12 @@ use crate::template::{
     readme_benchmarks::{self, Timings},
     ANSI_BOLD, ANSI_ITALIC, ANSI_RESET,
 };
+use crate::{every_day, Day};
 
 pub fn handle(is_release: bool, is_timed: bool) {
     let mut timings: Vec<Timings> = vec![];
 
-    (1..=25).for_each(|day| {
+    every_day().for_each(|day| {
         if day > 1 {
             println!();
         }
@@ -56,15 +57,15 @@ impl From<std::io::Error> for Error {
 }
 
 #[must_use]
-pub fn get_path_for_bin(day: usize) -> String {
-    let day_padded = format!("{day:02}");
-    format!("./src/bin/{day_padded}.rs")
+pub fn get_path_for_bin(day: Day) -> String {
+    format!("./src/bin/{day}.rs")
 }
 
 /// All solutions live in isolated binaries.
 /// This module encapsulates interaction with these binaries, both invoking them as well as parsing the timing output.
 mod child_commands {
     use super::{get_path_for_bin, Error};
+    use crate::Day;
     use std::{
         io::{BufRead, BufReader},
         path::Path,
@@ -73,18 +74,13 @@ mod child_commands {
     };
 
     /// Run the solution bin for a given day
-    pub fn run_solution(
-        day: usize,
-        is_timed: bool,
-        is_release: bool,
-    ) -> Result<Vec<String>, Error> {
-        let day_padded = format!("{day:02}");
-
+    pub fn run_solution(day: Day, is_timed: bool, is_release: bool) -> Result<Vec<String>, Error> {
         // skip command invocation for days that have not been scaffolded yet.
         if !Path::new(&get_path_for_bin(day)).exists() {
             return Ok(vec![]);
         }
 
+        let day_padded = day.to_string();
         let mut args = vec!["run", "--quiet", "--bin", &day_padded];
 
         if is_release {
@@ -129,7 +125,7 @@ mod child_commands {
         Ok(output)
     }
 
-    pub fn parse_exec_time(output: &[String], day: usize) -> super::Timings {
+    pub fn parse_exec_time(output: &[String], day: Day) -> super::Timings {
         let mut timings = super::Timings {
             day,
             part_1: None,

--- a/src/template/commands/download.rs
+++ b/src/template/commands/download.rs
@@ -1,7 +1,8 @@
 use crate::template::aoc_cli;
+use crate::Day;
 use std::process;
 
-pub fn handle(day: u8) {
+pub fn handle(day: Day) {
     if aoc_cli::check().is_err() {
         eprintln!("command \"aoc\" not found or not callable. Try running \"cargo install aoc-cli\" to install it.");
         process::exit(1);

--- a/src/template/commands/read.rs
+++ b/src/template/commands/read.rs
@@ -1,8 +1,9 @@
 use std::process;
 
 use crate::template::aoc_cli;
+use crate::Day;
 
-pub fn handle(day: u8) {
+pub fn handle(day: Day) {
     if aoc_cli::check().is_err() {
         eprintln!("command \"aoc\" not found or not callable. Try running \"cargo install aoc-cli\" to install it.");
         process::exit(1);

--- a/src/template/commands/scaffold.rs
+++ b/src/template/commands/scaffold.rs
@@ -4,6 +4,8 @@ use std::{
     process,
 };
 
+use crate::Day;
+
 const MODULE_TEMPLATE: &str = r#"pub fn part_one(input: &str) -> Option<u32> {
     None
 }
@@ -40,12 +42,10 @@ fn create_file(path: &str) -> Result<File, std::io::Error> {
     OpenOptions::new().write(true).create(true).open(path)
 }
 
-pub fn handle(day: u8) {
-    let day_padded = format!("{day:02}");
-
-    let input_path = format!("data/inputs/{day_padded}.txt");
-    let example_path = format!("data/examples/{day_padded}.txt");
-    let module_path = format!("src/bin/{day_padded}.rs");
+pub fn handle(day: Day) {
+    let input_path = format!("data/inputs/{day}.txt");
+    let example_path = format!("data/examples/{day}.txt");
+    let module_path = format!("src/bin/{day}.rs");
 
     let mut file = match safe_create_file(&module_path) {
         Ok(file) => file,
@@ -86,8 +86,5 @@ pub fn handle(day: u8) {
     }
 
     println!("---");
-    println!(
-        "🎄 Type `cargo solve {}` to run your solution.",
-        &day_padded
-    );
+    println!("🎄 Type `cargo solve {}` to run your solution.", day);
 }

--- a/src/template/commands/solve.rs
+++ b/src/template/commands/solve.rs
@@ -1,9 +1,9 @@
 use std::process::{Command, Stdio};
 
-pub fn handle(day: u8, release: bool, time: bool, submit_part: Option<u8>) {
-    let day_padded = format!("{day:02}");
+use crate::Day;
 
-    let mut cmd_args = vec!["run".to_string(), "--bin".to_string(), day_padded];
+pub fn handle(day: Day, release: bool, time: bool, submit_part: Option<u8>) {
+    let mut cmd_args = vec!["run".to_string(), "--bin".to_string(), day.to_string()];
 
     if release {
         cmd_args.push("--release".to_string());

--- a/src/template/readme_benchmarks.rs
+++ b/src/template/readme_benchmarks.rs
@@ -73,7 +73,7 @@ fn construct_table(prefix: &str, timings: Vec<Timings>, total_millis: f64) -> St
         let path = get_path_for_bin(timing.day);
         lines.push(format!(
             "| [Day {}]({}) | `{}` | `{}` |",
-            timing.day,
+            timing.day.into_inner(),
             path,
             timing.part_1.unwrap_or_else(|| "-".into()),
             timing.part_2.unwrap_or_else(|| "-".into())
@@ -105,23 +105,24 @@ pub fn update(timings: Vec<Timings>, total_millis: f64) -> Result<(), Error> {
 #[cfg(feature = "test_lib")]
 mod tests {
     use super::{update_content, Timings, MARKER};
+    use crate::Day;
 
     fn get_mock_timings() -> Vec<Timings> {
         vec![
             Timings {
-                day: 1,
+                day: Day::new(1).unwrap(),
                 part_1: Some("10ms".into()),
                 part_2: Some("20ms".into()),
                 total_nanos: 3e+10,
             },
             Timings {
-                day: 2,
+                day: Day::new(2).unwrap(),
                 part_1: Some("30ms".into()),
                 part_2: Some("40ms".into()),
                 total_nanos: 7e+10,
             },
             Timings {
-                day: 4,
+                day: Day::new(4).unwrap(),
                 part_1: Some("40ms".into()),
                 part_2: Some("50ms".into()),
                 total_nanos: 9e+10,

--- a/src/template/readme_benchmarks.rs
+++ b/src/template/readme_benchmarks.rs
@@ -2,6 +2,8 @@
 /// The approach taken is similar to how `aoc-readme-stars` handles this.
 use std::{fs, io};
 
+use crate::Day;
+
 static MARKER: &str = "<!--- benchmarking table --->";
 
 #[derive(Debug)]
@@ -18,7 +20,7 @@ impl From<std::io::Error> for Error {
 
 #[derive(Clone)]
 pub struct Timings {
-    pub day: usize,
+    pub day: Day,
     pub part_1: Option<String>,
     pub part_2: Option<String>,
     pub total_nanos: f64,
@@ -29,9 +31,9 @@ pub struct TablePosition {
     pos_end: usize,
 }
 
-#[must_use] pub fn get_path_for_bin(day: usize) -> String {
-    let day_padded = format!("{day:02}");
-    format!("./src/bin/{day_padded}.rs")
+#[must_use]
+pub fn get_path_for_bin(day: Day) -> String {
+    format!("./src/bin/{day}.rs")
 }
 
 fn locate_table(readme: &str) -> Result<TablePosition, Error> {

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -1,5 +1,6 @@
 /// Encapsulates code that interacts with solution functions.
 use crate::template::{aoc_cli, ANSI_ITALIC, ANSI_RESET};
+use crate::Day;
 use std::fmt::Display;
 use std::io::{stdout, Write};
 use std::process::Output;
@@ -8,7 +9,7 @@ use std::{cmp, env, process};
 
 use super::ANSI_BOLD;
 
-pub fn run_part<I: Clone, T: Display>(func: impl Fn(I) -> Option<T>, input: I, day: u8, part: u8) {
+pub fn run_part<I: Clone, T: Display>(func: impl Fn(I) -> Option<T>, input: I, day: Day, part: u8) {
     let part_str = format!("Part {part}");
 
     let (result, duration, samples) =
@@ -131,7 +132,7 @@ fn print_result<T: Display>(result: &Option<T>, part: &str, duration_str: &str) 
 ///  2. aoc-cli is installed.
 fn submit_result<T: Display>(
     result: T,
-    day: u8,
+    day: Day,
     part: u8,
 ) -> Option<Result<Output, aoc_cli::AocCommandError>> {
     let args: Vec<String> = env::args().collect();


### PR DESCRIPTION
Introduce a type `Day` to enforce static validity of the value and provide better error message to the user.
 
Before / after example with an invalid value
![image](https://github.com/fspoettel/advent-of-code-rust/assets/33934311/aa810b9c-811d-4767-938a-22965688240e)

