### PR TITLE
ci: fix readme-stars

### DIFF
--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -22,7 +22,7 @@ jobs:
                   userId: ${{ secrets.AOC_USER_ID }}
                   sessionCookie: ${{ secrets.AOC_SESSION }}
                   year: ${{ secrets.AOC_YEAR }}
-            - uses: stefanzweifel/git-auto-commit-action@v4
+            - uses: stefanzweifel/git-auto-commit-action@v5
               if: ${{ env.AOC_ENABLED }}
               env:
                   AOC_ENABLED: ${{ secrets.AOC_ENABLED }}

--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -10,7 +10,7 @@ jobs:
     update-readme:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               if: ${{ env.AOC_ENABLED }}
               env:
                   AOC_ENABLED: ${{ secrets.AOC_ENABLED }}

--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -9,24 +9,16 @@ on:
 jobs:
     update-readme:
         runs-on: ubuntu-latest
+        if: ${{ vars.AOC_ENABLED == 'true' }}
         permissions:
             contents: write
         steps:
             - uses: actions/checkout@v4
-              if: ${{ env.AOC_ENABLED == 'true' }}
-              env:
-                  AOC_ENABLED: ${{ secrets.AOC_ENABLED }}
             - uses: k2bd/advent-readme-stars@v1
-              if: ${{ env.AOC_ENABLED == 'true' }}
-              env:
-                  AOC_ENABLED: ${{ secrets.AOC_ENABLED }}
               with:
                   userId: ${{ secrets.AOC_USER_ID }}
                   sessionCookie: ${{ secrets.AOC_SESSION }}
                   year: ${{ secrets.AOC_YEAR }}
             - uses: stefanzweifel/git-auto-commit-action@v5
-              if: ${{ env.AOC_ENABLED == 'true' }}
-              env:
-                  AOC_ENABLED: ${{ secrets.AOC_ENABLED }}
               with:
                   commit_message: "update readme progess"

--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -13,11 +13,11 @@ jobs:
             contents: write
         steps:
             - uses: actions/checkout@v4
-              if: ${{ env.AOC_ENABLED }}
+              if: ${{ env.AOC_ENABLED == 'true' }}
               env:
                   AOC_ENABLED: ${{ secrets.AOC_ENABLED }}
             - uses: k2bd/advent-readme-stars@v1
-              if: ${{ env.AOC_ENABLED }}
+              if: ${{ env.AOC_ENABLED == 'true' }}
               env:
                   AOC_ENABLED: ${{ secrets.AOC_ENABLED }}
               with:
@@ -25,7 +25,7 @@ jobs:
                   sessionCookie: ${{ secrets.AOC_SESSION }}
                   year: ${{ secrets.AOC_YEAR }}
             - uses: stefanzweifel/git-auto-commit-action@v5
-              if: ${{ env.AOC_ENABLED }}
+              if: ${{ env.AOC_ENABLED == 'true' }}
               env:
                   AOC_ENABLED: ${{ secrets.AOC_ENABLED }}
               with:

--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -9,6 +9,8 @@ on:
 jobs:
     update-readme:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - uses: actions/checkout@v4
               if: ${{ env.AOC_ENABLED }}

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cargo read <day>
 ### Configure aoc-cli integration
 
 1. Install [`aoc-cli`](https://github.com/scarvalhojr/aoc-cli/) via cargo: `cargo install aoc-cli --version 0.12.0`
-2. Create an `.adventofcode.session` file in your home directory and paste your session cookie. To retrieve the session cookie, press F12 anywhere on the Advent of Code website to open your browser developer tools. Look in _Cookies_ under the _Application_ or _Storage_ tab, and copy out the `session` cookie value. [^1] 
+2. Create an `.adventofcode.session` file in your home directory and paste your session cookie. To retrieve the session cookie, press F12 anywhere on the Advent of Code website to open your browser developer tools. Look in _Cookies_ under the _Application_ or _Storage_ tab, and copy out the `session` cookie value. [^1]
 
 Once installed, you can use the [download command](#download-input--description-for-a-day) and automatically submit solutions via the [`--submit` flag](#submitting-solutions).
 
@@ -179,10 +179,13 @@ Go to the leaderboard page of the year you want to track and click _Private Lead
 
 Go to the _Secrets_ tab in your repository settings and create the following secrets:
 
--   `AOC_ENABLED`: This variable controls whether the workflow is enabled. Set it to `true` to enable the progress tracker.
 -   `AOC_USER_ID`: Go to [this page](https://adventofcode.com/settings) and copy your user id. It's the number behind the `#` symbol in the first name option. Example: `3031`.
 -   `AOC_YEAR`: the year you want to track. Example: `2021`.
 -   `AOC_SESSION`: an active session[^2] for the advent of code website. To get this, press F12 anywhere on the Advent of Code website to open your browser developer tools. Look in your Cookies under the Application or Storage tab, and copy out the `session` cookie.
+
+Go to the _Variables_ tab in your repository settings and create the following variable:
+
+-   `AOC_ENABLED`: This variable controls whether the workflow is enabled. Set it to `true` to enable the progress tracker.
 
 ✨ You can now run this action manually via the _Run workflow_ button on the workflow page. If you want the workflow to run automatically, uncomment the `schedule` section in the `readme-stars.yml` workflow file or add a `push` trigger.
 


### PR DESCRIPTION
- update `actions/checkout` to v4
- update `stefanzweifel/git-auto-commit-action` to v5
- add write permission, required by `stefanzweifel/git-auto-commit-action`
- fix run condition to run only if `AOC_ENABLED` has the value `true`
- move run condition to job so it stop sooner
- use variable for `AOC_ENABLED` since it's not a sensitive value and also because it's required to move the run condition on the job