### PR TITLE
refactor: move `Day` struct to `template` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,1 @@
-mod day;
 pub mod template;
-
-pub use day::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,8 @@ use advent_of_code::template::commands::{all, download, read, scaffold, solve};
 use args::{parse, AppArguments};
 
 mod args {
+    use advent_of_code::template::Day;
     use std::process;
-
-    use advent_of_code::Day;
 
     pub enum AppArguments {
         Download {

--- a/src/template/aoc_cli.rs
+++ b/src/template/aoc_cli.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Command, Output, Stdio},
 };
 
-use crate::Day;
+use crate::template::Day;
 
 #[derive(Debug)]
 pub enum AocCommandError {

--- a/src/template/commands/all.rs
+++ b/src/template/commands/all.rs
@@ -1,10 +1,10 @@
 use std::io;
 
 use crate::template::{
+    all_days,
     readme_benchmarks::{self, Timings},
-    ANSI_BOLD, ANSI_ITALIC, ANSI_RESET,
+    Day, ANSI_BOLD, ANSI_ITALIC, ANSI_RESET,
 };
-use crate::{all_days, Day};
 
 pub fn handle(is_release: bool, is_timed: bool) {
     let mut timings: Vec<Timings> = vec![];
@@ -65,7 +65,7 @@ pub fn get_path_for_bin(day: Day) -> String {
 /// This module encapsulates interaction with these binaries, both invoking them as well as parsing the timing output.
 mod child_commands {
     use super::{get_path_for_bin, Error};
-    use crate::Day;
+    use crate::template::Day;
     use std::{
         io::{BufRead, BufReader},
         path::Path,

--- a/src/template/commands/download.rs
+++ b/src/template/commands/download.rs
@@ -1,5 +1,4 @@
-use crate::template::aoc_cli;
-use crate::Day;
+use crate::template::{aoc_cli, Day};
 use std::process;
 
 pub fn handle(day: Day) {

--- a/src/template/commands/read.rs
+++ b/src/template/commands/read.rs
@@ -1,7 +1,6 @@
 use std::process;
 
-use crate::template::aoc_cli;
-use crate::Day;
+use crate::template::{aoc_cli, Day};
 
 pub fn handle(day: Day) {
     if aoc_cli::check().is_err() {

--- a/src/template/commands/scaffold.rs
+++ b/src/template/commands/scaffold.rs
@@ -4,7 +4,7 @@ use std::{
     process,
 };
 
-use crate::Day;
+use crate::template::Day;
 
 const MODULE_TEMPLATE: &str = r#"advent_of_code::solution!(DAY_NUMBER);
 

--- a/src/template/commands/solve.rs
+++ b/src/template/commands/solve.rs
@@ -1,6 +1,6 @@
 use std::process::{Command, Stdio};
 
-use crate::Day;
+use crate::template::Day;
 
 pub fn handle(day: Day, release: bool, time: bool, submit_part: Option<u8>) {
     let mut cmd_args = vec!["run".to_string(), "--bin".to_string(), day.to_string()];

--- a/src/template/day.rs
+++ b/src/template/day.rs
@@ -126,7 +126,7 @@ macro_rules! day {
                 "`, expecting a value between 1 and 25"
             ),
         );
-        $crate::Day::__new_unchecked($day)
+        $crate::template::Day::__new_unchecked($day)
     }};
 }
 

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,10 +1,12 @@
-use crate::Day;
 use std::{env, fs};
 
 pub mod aoc_cli;
 pub mod commands;
+mod day;
 pub mod readme_benchmarks;
 pub mod runner;
+
+pub use day::*;
 
 pub const ANSI_ITALIC: &str = "\x1b[3m";
 pub const ANSI_BOLD: &str = "\x1b[1m";
@@ -36,7 +38,7 @@ pub fn read_file_part(folder: &str, day: Day, part: u8) -> String {
 macro_rules! solution {
     ($day:expr) => {
         /// The current day.
-        const DAY: advent_of_code::Day = advent_of_code::day!($day);
+        const DAY: advent_of_code::template::Day = advent_of_code::day!($day);
 
         fn main() {
             use advent_of_code::template::runner::*;

--- a/src/template/readme_benchmarks.rs
+++ b/src/template/readme_benchmarks.rs
@@ -2,7 +2,7 @@
 /// The approach taken is similar to how `aoc-readme-stars` handles this.
 use std::{fs, io};
 
-use crate::Day;
+use crate::template::Day;
 
 static MARKER: &str = "<!--- benchmarking table --->";
 

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -1,6 +1,5 @@
 /// Encapsulates code that interacts with solution functions.
-use crate::template::{aoc_cli, ANSI_ITALIC, ANSI_RESET};
-use crate::Day;
+use crate::template::{aoc_cli, Day, ANSI_ITALIC, ANSI_RESET};
 use std::fmt::Display;
 use std::io::{stdout, Write};
 use std::process::Output;


### PR DESCRIPTION
`Day` is implementation detail and does not need to be visible as a top-level module (user-space).