### PR TITLE
Add command to scaffold, download input and read challenge for current date

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,5 @@
 [alias]
+today = "run --quiet --release -- today"
 scaffold = "run --quiet --release -- scaffold"
 download = "run --quiet --release -- download"
 read = "run --quiet --release -- read"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-today = "run --quiet --release -- today"
+today = "run --quiet --release --features today -- today"
 scaffold = "run --quiet --release -- scaffold"
 download = "run --quiet --release -- download"
 read = "run --quiet --release -- read"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,24 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 name = "advent_of_code"
 version = "0.9.5"
 dependencies = [
+ "chrono",
  "dhat",
  "pico-args",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -53,6 +69,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +88,26 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "dhat"
@@ -90,10 +132,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -116,6 +190,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -143,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
@@ -306,6 +395,69 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ test_lib = []
 dhat-heap = ["dhat"]
 
 [dependencies]
+chrono = "0.4.31"
 pico-args = "0.5.0"
 dhat = { version = "0.3.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,16 @@ publish = false
 [lib]
 doctest = false
 
+[profile.dhat]
+inherits = "release"
+debug = 1
+
 [features]
+today = ["chrono"]
 test_lib = []
 dhat-heap = ["dhat"]
 
 [dependencies]
-chrono = "0.4.31"
+chrono = { version = "0.4.31", optional = true }
 pico-args = "0.5.0"
 dhat = { version = "0.3.2", optional = true }
-
-[profile.dhat]
-inherits = "release"
-debug = 1

--- a/README.md
+++ b/README.md
@@ -161,7 +161,16 @@ cargo read <day>
 
 ### Scaffold, download and read in one go
 
-This command runs `cargo scaffold --download`, and `cargo read` for the current day.
+> [!IMPORTANT]
+> This command requires [installing the aoc-cli crate](#configure-aoc-cli-integration).
+
+During december, the `today` shorthand command can be used to:
+
+ - scaffold a solution for the current day
+ - download its input
+ - and read the puzzle
+
+in one go.
 
 ```sh
 # example: `cargo today` on December 1st

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cargo read <day>
 
 ### Scaffold, download and read in one go
 
-This command runs `cargo scaffold`, `cargo download` and `cargo read` for the current day.
+This command runs `cargo scaffold --download`, and `cargo read` for the current day.
 
 ```sh
 # example: `cargo today` on December 1st

--- a/README.md
+++ b/README.md
@@ -74,22 +74,6 @@ cargo download <day>
 # 🎄 Successfully wrote puzzle to "data/puzzles/01.md".
 ```
 
-### Scaffold and download in one go
-
-This command runs `cargo scaffold` and `cargo download` for the current day.
-
-```sh
-cargo today
-
-# output:
-# [INFO  aoc] 🎄 aoc-cli - Advent of Code command-line tool
-# [INFO  aoc_client] 🎅 Saved puzzle to 'data/puzzles/01.md'
-# [INFO  aoc_client] 🎅 Saved input to 'data/inputs/01.txt'
-# ---
-# 🎄 Successfully wrote input to "data/inputs/01.txt".
-# 🎄 Successfully wrote puzzle to "data/puzzles/01.md".
-```
-
 ### Run solutions for a day
 
 ```sh
@@ -170,6 +154,32 @@ cargo clippy
 cargo read <day>
 
 # output:
+# Loaded session cookie from "/Users/<snip>/.adventofcode.session".
+# Fetching puzzle for day 1, 2022...
+# ...the input...
+```
+
+### Scaffold, download and read in one go
+
+This command runs `cargo scaffold`, `cargo download` and `cargo read` for the current day.
+
+```sh
+# example: `cargo today` on December 1st
+cargo today
+
+# output:
+# Created module file "src/bin/01.rs"
+# Created empty input file "data/inputs/01.txt"
+# Created empty example file "data/examples/01.txt"
+# ---
+# 🎄 Type `cargo solve 01` to run your solution.
+# [INFO  aoc] 🎄 aoc-cli - Advent of Code command-line tool
+# [INFO  aoc_client] 🎅 Saved puzzle to 'data/puzzles/01.md'
+# [INFO  aoc_client] 🎅 Saved input to 'data/inputs/01.txt'
+# ---
+# 🎄 Successfully wrote input to "data/inputs/01.txt".
+# 🎄 Successfully wrote puzzle to "data/puzzles/01.md".
+#
 # Loaded session cookie from "/Users/<snip>/.adventofcode.session".
 # Fetching puzzle for day 1, 2022...
 # ...the input...

--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ cargo download <day>
 # 🎄 Successfully wrote puzzle to "data/puzzles/01.md".
 ```
 
+### Scaffold and download in one go
+
+This command runs `cargo scaffold` and `cargo download` for the current day.
+
+```sh
+cargo today
+
+# output:
+# [INFO  aoc] 🎄 aoc-cli - Advent of Code command-line tool
+# [INFO  aoc_client] 🎅 Saved puzzle to 'data/puzzles/01.md'
+# [INFO  aoc_client] 🎅 Saved input to 'data/inputs/01.txt'
+# ---
+# 🎄 Successfully wrote input to "data/inputs/01.txt".
+# 🎄 Successfully wrote puzzle to "data/puzzles/01.md".
+```
+
 ### Run solutions for a day
 
 ```sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-use std::process;
-
-use advent_of_code::template::{
-    commands::{all, download, read, scaffold, solve},
-    Day,
-};
+use advent_of_code::template::commands::{all, download, read, scaffold, solve};
 use args::{parse, AppArguments};
+
+#[cfg(feature = "today")]
+use advent_of_code::template::Day;
+#[cfg(feature = "today")]
+use std::process;
 
 mod args {
     use advent_of_code::template::Day;
@@ -21,7 +21,6 @@ mod args {
             day: Day,
             download: bool,
         },
-        Today,
         Solve {
             day: Day,
             release: bool,
@@ -33,6 +32,8 @@ mod args {
             release: bool,
             time: bool,
         },
+        #[cfg(feature = "today")]
+        Today,
     }
 
     pub fn parse() -> Result<AppArguments, Box<dyn std::error::Error>> {
@@ -60,6 +61,7 @@ mod args {
                 time: args.contains("--time"),
                 dhat: args.contains("--dhat"),
             },
+            #[cfg(feature = "today")]
             Some("today") => AppArguments::Today,
             Some(x) => {
                 eprintln!("Unknown command: {x}");
@@ -103,6 +105,7 @@ fn main() {
                 dhat,
                 submit,
             } => solve::handle(day, release, time, dhat, submit),
+            #[cfg(feature = "today")]
             AppArguments::Today => {
                 match Day::today() {
                     Some(day) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
-use advent_of_code::template::commands::{all, download, read, scaffold, solve};
+use std::process;
+
+use advent_of_code::template::{
+    commands::{all, download, read, scaffold, solve},
+    Day,
+};
 use args::{parse, AppArguments};
-use chrono::Local;
 
 mod args {
     use advent_of_code::template::Day;
@@ -100,13 +104,19 @@ fn main() {
                 submit,
             } => solve::handle(day, release, time, dhat, submit),
             AppArguments::Today => {
-                match Local::now().try_into() {
-                    Ok(day) => {
+                match Day::today() {
+                    Some(day) => {
                         scaffold::handle(day);
                         download::handle(day);
                         read::handle(day)
                     }
-                    Err(e) => println!("{e}"),
+                    None => {
+                        eprintln!(
+                            "`today` command can only be run between the 1st and \
+                            the 25th of december. Please use `scaffold` with a specific day."
+                        );
+                        process::exit(1)
+                    }
                 };
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use advent_of_code::template::commands::{all, download, read, scaffold, solve};
 use args::{parse, AppArguments};
+use chrono::Local;
 
 mod args {
     use advent_of_code::template::Day;
@@ -16,6 +17,7 @@ mod args {
             day: Day,
             download: bool,
         },
+        Today,
         Solve {
             day: Day,
             release: bool,
@@ -54,6 +56,7 @@ mod args {
                 time: args.contains("--time"),
                 dhat: args.contains("--dhat"),
             },
+            Some("today") => AppArguments::Today,
             Some(x) => {
                 eprintln!("Unknown command: {x}");
                 process::exit(1);
@@ -96,6 +99,16 @@ fn main() {
                 dhat,
                 submit,
             } => solve::handle(day, release, time, dhat, submit),
+            AppArguments::Today => {
+                match Local::now().try_into() {
+                    Ok(day) => {
+                        scaffold::handle(day);
+                        download::handle(day);
+                        read::handle(day)
+                    }
+                    Err(e) => println!("{e}"),
+                };
+            }
         },
     };
 }

--- a/src/template/day.rs
+++ b/src/template/day.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Datelike, Local};
+use chrono::{Datelike, Local};
 use std::error::Error;
 use std::fmt::Display;
 use std::str::FromStr;
@@ -38,15 +38,15 @@ impl Day {
     }
 }
 
-impl TryFrom<DateTime<Local>> for Day {
-    type Error = &'static str;
-
-    fn try_from(date: DateTime<Local>) -> Result<Self, Self::Error> {
-        let day = date.day();
-        if date.month() != 12 || day == 0 || day > 25 {
-            return Err("Cannot run this command on a day outside of the Advent of Code days.");
+impl Day {
+    /// Returns the current day if it's between the 1st and the 25th of december, `None` otherwise.
+    pub fn today() -> Option<Self> {
+        let today = Local::now();
+        if today.month() == 12 && today.day() <= 25 {
+            Self::new(u8::try_from(today.day()).ok()?)
+        } else {
+            None
         }
-        Ok(Self(day as u8))
     }
 }
 

--- a/src/template/day.rs
+++ b/src/template/day.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Datelike, Local};
 use std::error::Error;
 use std::fmt::Display;
 use std::str::FromStr;
@@ -34,6 +35,18 @@ impl Day {
     /// Converts the [`Day`] into an [`u8`].
     pub fn into_inner(self) -> u8 {
         self.0
+    }
+}
+
+impl TryFrom<DateTime<Local>> for Day {
+    type Error = &'static str;
+
+    fn try_from(date: DateTime<Local>) -> Result<Self, Self::Error> {
+        let day = date.day();
+        if date.month() != 12 || day == 0 || day > 25 {
+            return Err("Cannot run this command on a day outside of the Advent of Code days.");
+        }
+        Ok(Self(day as u8))
     }
 }
 

--- a/src/template/day.rs
+++ b/src/template/day.rs
@@ -1,7 +1,9 @@
-use chrono::{Datelike, Local};
 use std::error::Error;
 use std::fmt::Display;
 use std::str::FromStr;
+
+#[cfg(feature = "today")]
+use chrono::{Datelike, Local};
 
 /// A valid day number of advent (i.e. an integer in range 1 to 25).
 ///
@@ -38,6 +40,7 @@ impl Day {
     }
 }
 
+#[cfg(feature = "today")]
 impl Day {
     /// Returns the current day if it's between the 1st and the 25th of december, `None` otherwise.
     pub fn today() -> Option<Self> {


### PR DESCRIPTION
This pull request combines the scaffold, download and read commands into one, auto selecting the current date or accepting an optional day.

Command:
```sh
cargo today [<day>]
```