### PR TITLE
feat: add macro arms for only running single parts of a solution

### DIFF
--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -34,6 +34,8 @@ pub fn read_file_part(folder: &str, day: Day, part: u8) -> String {
 }
 
 /// Creates the constant `DAY` and sets up the input and runner for each part.
+///
+/// The optional, second parameter (1 or 2) allows you to only run a single part of the solution.
 #[macro_export]
 macro_rules! solution {
     ($day:expr) => {
@@ -47,7 +49,8 @@ macro_rules! solution {
             run_part(part_two, &input, DAY, 2);
         }
     };
-    ($day:expr, 1) => { /// Allows solving part one in isolation
+    ($day:expr, 1) => {
+        /// Allows solving part one in isolation
         const DAY: advent_of_code::template::Day = advent_of_code::day!($day);
 
         fn main() {
@@ -56,7 +59,8 @@ macro_rules! solution {
             run_part(part_one, &input, DAY, 1);
         }
     };
-    ($day:expr, 2) => { /// Allows solving part two in isolation
+    ($day:expr, 2) => {
+        /// Allows solving part two in isolation
         const DAY: advent_of_code::template::Day = advent_of_code::day!($day);
 
         fn main() {

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -45,4 +45,22 @@ macro_rules! solution {
             run_part(part_two, &input, DAY, 2);
         }
     };
+    ($day:expr, 1) => { /// Allows solving part one in isolation
+        const DAY: advent_of_code::Day = advent_of_code::day!($day);
+
+        fn main() {
+            use advent_of_code::template::runner::*;
+            let input = advent_of_code::template::read_file("inputs", DAY);
+            run_part(part_one, &input, DAY, 1);
+        }
+    };
+    ($day:expr, 2) => { /// Allows solving part two in isolation
+        const DAY: advent_of_code::Day = advent_of_code::day!($day);
+
+        fn main() {
+            use advent_of_code::template::runner::*;
+            let input = advent_of_code::template::read_file("inputs", DAY);
+            run_part(part_two, &input, DAY, 2);
+        }
+    };
 }


### PR DESCRIPTION
The current solution macro attempts to run both parts of a days solution. This modification is handy when working on part 1 to enable the part 1 solution to be run without worrying about part 2.