### PR TITLE
feat: use black_box for benchmark evaluation

### DIFF
--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -1,6 +1,7 @@
 /// Encapsulates code that interacts with solution functions.
 use crate::template::{aoc_cli, Day, ANSI_ITALIC, ANSI_RESET};
 use std::fmt::Display;
+use std::hint::black_box;
 use std::io::{stdout, Write};
 use std::process::Output;
 use std::time::{Duration, Instant};
@@ -64,7 +65,7 @@ fn bench<I: Clone, T>(func: impl Fn(I) -> T, input: I, base_time: &Duration) -> 
         // need a clone here to make the borrow checker happy.
         let cloned = input.clone();
         let timer = Instant::now();
-        func(cloned);
+        black_box(func(black_box(cloned)));
         timers.push(timer.elapsed());
     }
 


### PR DESCRIPTION
This prevents cases where subsequent invocations of the solution fully unroll it, leading to deceivingly low execution times being reported.

Adopted from https://github.com/bheisler/criterion.rs/blob/b913e232edd98780961ecfbae836ec77ede49259/src/lib.rs#L151-L158