### PR TITLE
Make `time` command less noisy

### DIFF
--- a/src/template/run_multi.rs
+++ b/src/template/run_multi.rs
@@ -11,7 +11,8 @@ pub fn run_multi(days_to_run: &HashSet<Day>, is_release: bool, is_timed: bool) -
     let mut timings: Vec<Timing> = Vec::with_capacity(days_to_run.len());
 
     let mut need_space = false;
-    // NOTE: we didn't want duplicate day value, but we want days to be sorted.
+
+    // NOTE: use non-duplicate, sorted day values.
     all_days()
         .filter(|day| days_to_run.contains(day))
         .for_each(|day| {

--- a/src/template/run_multi.rs
+++ b/src/template/run_multi.rs
@@ -10,28 +10,28 @@ use super::{
 pub fn run_multi(days_to_run: &HashSet<Day>, is_release: bool, is_timed: bool) -> Option<Timings> {
     let mut timings: Vec<Timing> = Vec::with_capacity(days_to_run.len());
 
-    all_days().for_each(|day| {
-        if day > 1 {
-            println!();
-        }
+    let mut need_space = false;
+    // NOTE: we didn't want duplicate day value, but we want days to be sorted.
+    all_days()
+        .filter(|day| days_to_run.contains(day))
+        .for_each(|day| {
+            if need_space {
+                println!();
+            }
+            need_space = true;
 
-        println!("{ANSI_BOLD}Day {day}{ANSI_RESET}");
-        println!("------");
+            println!("{ANSI_BOLD}Day {day}{ANSI_RESET}");
+            println!("------");
 
-        if !days_to_run.contains(&day) {
-            println!("Skipped.");
-            return;
-        }
+            let output = child_commands::run_solution(day, is_timed, is_release).unwrap();
 
-        let output = child_commands::run_solution(day, is_timed, is_release).unwrap();
-
-        if output.is_empty() {
-            println!("Not solved.");
-        } else {
-            let val = child_commands::parse_exec_time(&output, day);
-            timings.push(val);
-        }
-    });
+            if output.is_empty() {
+                println!("Not solved.");
+            } else {
+                let val = child_commands::parse_exec_time(&output, day);
+                timings.push(val);
+            }
+        });
 
     if is_timed {
         let timings = Timings { data: timings };


### PR DESCRIPTION
Make `cargo time` less noisy by not printing day if skipped.
Especially useful when using `cargo time <day>`.