### PR TITLE
Add a `--no-readme` flag to time command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Solutions for [Advent of Code](https://adventofcode.com/) in [Rust](https://www.
 
 This template supports all major OS (macOS, Linux, Windows).
 
-###  📝 Create your repository
+### 📝 Create your repository
 
 1.  Open [the template repository](https://github.com/fspoettel/advent-of-code-rust) on Github.
 2.  Click [Use this template](https://github.com/fspoettel/advent-of-code-rust/generate) and create your repository.
@@ -56,7 +56,7 @@ Every [solution](https://github.com/fspoettel/advent-of-code-rust/blob/main/src/
 
 ### ➡️ Download input for a day
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > This requires [installing the aoc-cli crate](#configure-aoc-cli-integration).
 
 You can automatically download puzzle input and description by either appending the `--download` flag to `scaffold` (e.g. `cargo scaffold 4 --download`) or with the separate `download` command:
@@ -126,6 +126,8 @@ By default, this command checks for missing benchmarks, runs those solutions, an
 
 Please note that these are not _scientific_ benchmarks, understand them as a fun approximation. 😉 Timings, especially in the microseconds range, might change a bit between invocations.
 
+To compute the times but not update the benchmarks table in the readme, use the `--no-readme` flag.
+
 ### ➡️ Run all tests
 
 ```sh
@@ -156,9 +158,9 @@ cargo read <day>
 
 During december, the `today` shorthand command can be used to:
 
- - scaffold a solution for the current day
- - download its input
- - and read the puzzle
+-   scaffold a solution for the current day
+-   download its input
+-   and read the puzzle
 
 in one go.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod args {
         },
         Time {
             all: bool,
+            no_readme: bool,
             day: Option<Day>,
         },
         #[cfg(feature = "today")]
@@ -50,9 +51,11 @@ mod args {
             },
             Some("time") => {
                 let all = args.contains("--all");
+                let no_readme = args.contains("--no-readme");
 
                 AppArguments::Time {
                     all,
+                    no_readme,
                     day: args.opt_free_from_str()?,
                 }
             }
@@ -102,7 +105,11 @@ fn main() {
         }
         Ok(args) => match args {
             AppArguments::All { release, time } => all::handle(release, time),
-            AppArguments::Time { day, all } => time::handle(day, all),
+            AppArguments::Time {
+                day,
+                all,
+                no_readme,
+            } => time::handle(day, all, !no_readme),
             AppArguments::Download { day } => download::handle(day),
             AppArguments::Read { day } => read::handle(day),
             AppArguments::Scaffold { day, download } => {

--- a/src/template/commands/time.rs
+++ b/src/template/commands/time.rs
@@ -4,7 +4,7 @@ use crate::template::run_multi::run_multi;
 use crate::template::timings::Timings;
 use crate::template::{all_days, readme_benchmarks, Day};
 
-pub fn handle(day: Option<Day>, recreate_all: bool) {
+pub fn handle(day: Option<Day>, recreate_all: bool, update_readme: bool) {
     let stored_timings = Timings::read_from_file();
 
     let days_to_run = day.map_or_else(
@@ -26,13 +26,15 @@ pub fn handle(day: Option<Day>, recreate_all: bool) {
     let merged_timings = stored_timings.merge(&timings);
     merged_timings.store_file().unwrap();
 
-    println!();
-    match readme_benchmarks::update(merged_timings) {
-        Ok(()) => {
-            println!("Stored updated benchmarks.");
-        }
-        Err(_) => {
-            eprintln!("Failed to store updated benchmarks.");
+    if update_readme {
+        println!();
+        match readme_benchmarks::update(merged_timings) {
+            Ok(()) => {
+                println!("Stored updated benchmarks.");
+            }
+            Err(_) => {
+                eprintln!("Failed to store updated benchmarks.");
+            }
         }
     }
 }


### PR DESCRIPTION
Allow to not update readme table every time `time` is called.
Especially when using `cargo time <day>` multiple time in row.