### PR TITLE
Use server time for `cargo today`

### DIFF
--- a/src/template/day.rs
+++ b/src/template/day.rs
@@ -3,7 +3,10 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 #[cfg(feature = "today")]
-use chrono::{Datelike, Local};
+use chrono::{Datelike, FixedOffset, Utc};
+
+#[cfg(feature = "today")]
+const SERVER_UTC_OFFSET: i32 = -5;
 
 /// A valid day number of advent (i.e. an integer in range 1 to 25).
 ///
@@ -44,7 +47,8 @@ impl Day {
 impl Day {
     /// Returns the current day if it's between the 1st and the 25th of december, `None` otherwise.
     pub fn today() -> Option<Self> {
-        let today = Local::now();
+        let offset = FixedOffset::east_opt(SERVER_UTC_OFFSET * 3600)?;
+        let today = Utc::now().with_timezone(&offset);
         if today.month() == 12 && today.day() <= 25 {
             Self::new(u8::try_from(today.day()).ok()?)
         } else {


### PR DESCRIPTION
`cargo today` currently uses local time instead of server time for determining the date.