### PR TITLE
Use u64 to represent solutions

### DIFF
--- a/src/template.txt
+++ b/src/template.txt
@@ -1,10 +1,10 @@
 advent_of_code::solution!(%DAY_NUMBER%);
 
-pub fn part_one(input: &str) -> Option<u32> {
+pub fn part_one(input: &str) -> Option<u64> {
     None
 }
 
-pub fn part_two(input: &str) -> Option<u32> {
+pub fn part_two(input: &str) -> Option<u64> {
     None
 }
 


### PR DESCRIPTION
Hello, it's been a great experience using the template this year :)

Today was the second time this year (I think) where the answer was too large for a u32, so in line with #74 I'm making this PR to bump it to u64 instead.

Fixes #74