### PR TITLE
Multi-year support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-today = "run --quiet --release --features today -- today"
+today = "run --quiet --release -- today"
 scaffold = "run --quiet --release -- scaffold"
 download = "run --quiet --release -- download"
 read = "run --quiet --release -- read"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,7 @@ today = "run --quiet --release --features today -- today"
 scaffold = "run --quiet --release -- scaffold"
 download = "run --quiet --release -- download"
 read = "run --quiet --release -- read"
+switch-year = "run --quiet --release -- switch-year"
 
 solve = "run --quiet --release -- solve"
 all = "run --quiet --release -- all"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ data/inputs/*
 !data/inputs/.keep
 data/puzzles/*
 !data/puzzles/.keep
+years/*/inputs/*
+!years/*/inputs/.keep
+years/*/puzzles/*
+!years/*/puzzles/.keep
 
 # Dhat
 dhat-heap.json
@@ -28,3 +32,4 @@ dhat-heap.json
 # Benchmarks
 
 data/timings.json
+years/*/timings.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ version = "0.11.0"
 dependencies = [
  "chrono",
  "dhat",
+ "fs_extra",
  "pico-args",
  "tinyjson",
 ]
@@ -125,6 +126,12 @@ dependencies = [
  "serde_json",
  "thousands",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "gimli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ debug = 1
 
 [features]
 dhat-heap = ["dhat"]
-today = []
 test_lib = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,16 @@ debug = 1
 
 [features]
 dhat-heap = ["dhat"]
-today = ["chrono"]
+today = []
 test_lib = []
 
 [dependencies]
 
 # Template dependencies
-chrono = { version = "0.4.38", optional = true }
+chrono = "0.4.38"
 dhat = { version = "0.3.3", optional = true }
 pico-args = "0.5.0"
 tinyjson = "2.5.1"
+fs_extra = "1.3.0"
 
 # Solution dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./.assets/christmas_ferris.png" width="164">
 
-# 🎄 Advent of Code {year}
+# 🎄 Advent of Code
 
 Solutions for [Advent of Code](https://adventofcode.com/) in [Rust](https://www.rust-lang.org/).
 
@@ -200,6 +200,28 @@ cargo today
 # Fetching puzzle for day 1, 2022...
 # ...the input...
 ```
+
+### ➡️ Change year
+
+You can use the `switch-year` command to navigate through years.
+
+The files of the year defined in the environment variable `AOC_YEAR` in `.cargo/config.toml` are as usual in `src/` and `data/` folders, while the others are stored in `years/{AOC_YEAR}/`. Benchmarks on the readme are automatically updated.
+
+```sh
+# example: `cargo switch-year 2015` with no files already written for 2015
+cargo switch-year 2015
+
+# output:
+# No existing files for year 2015, generating blank folders.
+# ---
+# 🎄 Successfully switched to year 2015.
+```
+
+> [!TIP]
+> Remember to switch to the last event year before doing any commits on your personal repo, or else you will have many files changes as there were moved during year switches.
+
+> Please note that [stars tracking](#automatically-track-️-progress-in-the-readme) will still track the year you specified in the GitHub action and will not be changed.
+
 
 ### ➡️ Format code
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
 use advent_of_code::template::commands::{all, download, read, scaffold, solve, switchyear, time};
+use advent_of_code::template::Day;
 use advent_of_code::template::{ANSI_BOLD, ANSI_RESET};
 use args::{parse, AppArguments};
-
-#[cfg(feature = "today")]
-use advent_of_code::template::Day;
-#[cfg(feature = "today")]
 use std::process;
 
 mod args {
@@ -37,7 +34,6 @@ mod args {
             day: Option<Day>,
             store: bool,
         },
-        #[cfg(feature = "today")]
         Today,
         SwitchYear {
             year: Year,
@@ -78,7 +74,6 @@ mod args {
                 submit: args.opt_value_from_str("--submit")?,
                 dhat: args.contains("--dhat"),
             },
-            #[cfg(feature = "today")]
             Some("today") => AppArguments::Today,
             Some("switch-year") => AppArguments::SwitchYear {
                 year: args.free_from_str()?,
@@ -133,7 +128,6 @@ fn main() {
                 dhat,
                 submit,
             } => solve::handle(day, release, dhat, submit),
-            #[cfg(feature = "today")]
             AppArguments::Today => {
                 match Day::today() {
                     Some(day) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use advent_of_code::template::commands::{all, download, read, scaffold, solve, time};
+use advent_of_code::template::commands::{all, download, read, scaffold, solve, switchyear, time};
+use advent_of_code::template::{ANSI_BOLD, ANSI_RESET};
 use args::{parse, AppArguments};
 
 #[cfg(feature = "today")]
@@ -7,7 +8,7 @@ use advent_of_code::template::Day;
 use std::process;
 
 mod args {
-    use advent_of_code::template::Day;
+    use advent_of_code::template::{Day, Year};
     use std::process;
 
     pub enum AppArguments {
@@ -38,6 +39,9 @@ mod args {
         },
         #[cfg(feature = "today")]
         Today,
+        SwitchYear {
+            year: Year,
+        },
     }
 
     pub fn parse() -> Result<AppArguments, Box<dyn std::error::Error>> {
@@ -76,6 +80,9 @@ mod args {
             },
             #[cfg(feature = "today")]
             Some("today") => AppArguments::Today,
+            Some("switch-year") => AppArguments::SwitchYear {
+                year: args.free_from_str()?,
+            },
             Some(x) => {
                 eprintln!("Unknown command: {x}");
                 process::exit(1);
@@ -96,6 +103,10 @@ mod args {
 }
 
 fn main() {
+    println!(
+        "🎄{ANSI_BOLD} Advent of Code {} {ANSI_RESET}🎄",
+        std::env::var("AOC_YEAR").unwrap()
+    );
     match parse() {
         Err(err) => {
             eprintln!("Error: {err}");
@@ -126,6 +137,7 @@ fn main() {
             AppArguments::Today => {
                 match Day::today() {
                     Some(day) => {
+                        switchyear::handle_today();
                         scaffold::handle(day, false);
                         download::handle(day);
                         read::handle(day)
@@ -138,6 +150,9 @@ fn main() {
                         process::exit(1)
                     }
                 };
+            }
+            AppArguments::SwitchYear { year } => {
+                switchyear::handle(year);
             }
         },
     };

--- a/src/template/commands/mod.rs
+++ b/src/template/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod download;
 pub mod read;
 pub mod scaffold;
 pub mod solve;
+pub mod switchyear;
 pub mod time;

--- a/src/template/commands/switchyear.rs
+++ b/src/template/commands/switchyear.rs
@@ -13,7 +13,6 @@ pub fn handle(year: Year) {
     }
 }
 
-#[cfg(feature = "today")]
 pub fn handle_today() {
     let year = Year::this_year().unwrap();
     let env_year = Year::new(env::var("AOC_YEAR").unwrap().parse().unwrap()).unwrap();

--- a/src/template/commands/switchyear.rs
+++ b/src/template/commands/switchyear.rs
@@ -1,0 +1,89 @@
+use crate::template::year::Year;
+use std::{collections::HashSet, env, fs, path::PathBuf};
+
+extern crate fs_extra;
+
+pub fn handle(year: Year) {
+    let env_year = Year::__new_unchecked(env::var("AOC_YEAR").unwrap().parse().unwrap());
+    if year == env_year {
+        println!("🔔 You are already in the year you want to switch to.");
+    } else {
+        switch_to_year(year, env_year);
+        println!("🎄 Switched to year {}.", year.into_inner());
+    }
+}
+
+#[cfg(feature = "today")]
+pub fn handle_today() {
+    let year = Year::this_year().unwrap();
+    let env_year = Year::new(env::var("AOC_YEAR").unwrap().parse().unwrap()).unwrap();
+    if year != env_year {
+        switch_to_year(year, env_year);
+        println!(
+            "🎄 Automatically switched to this year: {}.",
+            year.into_inner()
+        );
+    }
+}
+
+fn clean_folder(path: PathBuf) {
+    let paths = fs::read_dir(path).unwrap();
+    let mut files = HashSet::new();
+    for path in paths {
+        let path = path.unwrap().path();
+        if path.is_file() && path.file_name().unwrap() != ".keep" {
+            files.insert(path);
+        }
+    }
+    for file in files {
+        fs::remove_file(file).unwrap();
+    }
+}
+
+pub fn switch_to_year(year: Year, previous_year: Year) {
+    let cwd = env::current_dir().unwrap();
+
+    // Move src and data files to years/
+    let src = cwd.join("src");
+    let data = cwd.join("data");
+    let bin = src.join("bin");
+    let examples = data.join("examples");
+    let inputs = data.join("inputs");
+    let puzzles = data.join("puzzles");
+    let years = cwd.join("years");
+    let destination = years.join(previous_year.into_inner().to_string());
+
+    let default_copy = fs_extra::dir::CopyOptions::new();
+    fs_extra::dir::create(&destination, true).unwrap();
+    fs_extra::dir::move_dir(&bin, &destination, &default_copy).unwrap();
+    fs_extra::dir::move_dir(&examples, &destination, &default_copy).unwrap();
+    clean_folder(inputs);
+    clean_folder(puzzles);
+
+    // Move years/ to src and data files
+    let source = years.join(year.into_inner().to_string());
+    if source.exists() {
+        let source_bin = source.join("bin");
+        let source_examples = source.join("examples");
+        fs_extra::dir::move_dir(&source_bin, &src, &default_copy).unwrap();
+        fs_extra::dir::move_dir(&source_examples, &data, &default_copy).unwrap();
+        fs_extra::dir::remove(&source).unwrap();
+    } else {
+        fs::create_dir(&bin).unwrap();
+        fs::create_dir(&examples).unwrap();
+        fs::write(bin.join(".keep"), "").unwrap();
+        fs::write(examples.join(".keep"), "").unwrap();
+    }
+
+    // Set the environment variable
+    std::env::set_var("AOC_YEAR", year.into_inner().to_string());
+
+    // Write Cargo.toml
+    let config_toml = cwd.join(".cargo").join("config.toml");
+    let config_toml_content = fs::read_to_string(&config_toml).unwrap();
+    let config_toml_updated_content = config_toml_content.replace(
+        &previous_year.into_inner().to_string(),
+        &year.into_inner().to_string(),
+    );
+    fs::write(config_toml, config_toml_updated_content).unwrap();
+}

--- a/src/template/commands/switchyear.rs
+++ b/src/template/commands/switchyear.rs
@@ -85,4 +85,7 @@ pub fn switch_to_year(year: Year, previous_year: Year) {
         &year.into_inner().to_string(),
     );
     fs::write(config_toml, config_toml_updated_content).unwrap();
+
+    // Update benchmarks in README.md
+    crate::template::readme_benchmarks::update_after_switch_year().unwrap();
 }

--- a/src/template/day.rs
+++ b/src/template/day.rs
@@ -1,11 +1,8 @@
+use chrono::{Datelike, FixedOffset, Utc};
 use std::error::Error;
 use std::fmt::Display;
 use std::str::FromStr;
 
-#[cfg(feature = "today")]
-use chrono::{Datelike, FixedOffset, Utc};
-
-#[cfg(feature = "today")]
 const SERVER_UTC_OFFSET: i32 = -5;
 
 /// A valid day number of advent (i.e. an integer in range 1 to 25).
@@ -41,10 +38,7 @@ impl Day {
     pub fn into_inner(self) -> u8 {
         self.0
     }
-}
 
-#[cfg(feature = "today")]
-impl Day {
     /// Returns the current day if it's between the 1st and the 25th of december, `None` otherwise.
     pub fn today() -> Option<Self> {
         let offset = FixedOffset::east_opt(SERVER_UTC_OFFSET * 3600)?;

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -5,11 +5,13 @@ pub mod commands;
 pub mod runner;
 
 pub use day::*;
+pub use year::*;
 
 mod day;
 mod readme_benchmarks;
 mod run_multi;
 mod timings;
+mod year;
 
 pub const ANSI_ITALIC: &str = "\x1b[3m";
 pub const ANSI_BOLD: &str = "\x1b[1m";

--- a/src/template/readme_benchmarks.rs
+++ b/src/template/readme_benchmarks.rs
@@ -53,7 +53,10 @@ fn locate_table(readme: &str) -> Result<TablePosition, Error> {
 }
 
 fn construct_table(prefix: &str, timings: Timings, total_millis: f64) -> String {
-    let header = format!("{prefix} Benchmarks");
+    let header = format!(
+        "{prefix} Benchmarks for {}",
+        std::env::var("AOC_YEAR").unwrap()
+    );
 
     let mut lines: Vec<String> = vec![
         MARKER.into(),
@@ -95,6 +98,24 @@ pub fn update(timings: Timings) -> Result<(), Error> {
     update_content(&mut readme, timings, total_millis)?;
     fs::write(path, &readme)?;
     Ok(())
+}
+
+fn remove_benchmarks() {
+    let path = "README.md";
+    let mut readme = String::from_utf8_lossy(&fs::read(path).unwrap()).to_string();
+    let positions = locate_table(&readme).unwrap();
+    readme.replace_range(positions.pos_start..positions.pos_end, MARKER);
+    fs::write(path, &readme).unwrap();
+}
+
+pub fn update_after_switch_year() -> Result<(), Error> {
+    let timings = Timings::read_from_file();
+    if timings.data.is_empty() {
+        remove_benchmarks();
+        Ok(())
+    } else {
+        update(timings)
+    }
 }
 
 #[cfg(feature = "test_lib")]

--- a/src/template/year.rs
+++ b/src/template/year.rs
@@ -1,0 +1,99 @@
+use std::error::Error;
+use std::fmt::Display;
+use std::str::FromStr;
+
+extern crate chrono;
+use chrono::{Datelike, FixedOffset, Utc};
+
+const SERVER_UTC_OFFSET: i32 = -5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Year(i32);
+
+impl Year {
+    /// Creates a [`Year`] from the provided value if it's in the valid range,
+    /// returns [`None`] otherwise.
+    pub fn new(year: i32) -> Option<Self> {
+        if 2015 <= year && year <= Year::last_year().into_inner() {
+            Some(Self(year))
+        } else {
+            None
+        }
+    }
+
+    // Not part of the public API
+    #[doc(hidden)]
+    pub const fn __new_unchecked(year: i32) -> Self {
+        Self(year)
+    }
+
+    /// Converts the [`year`] into an [`i32`].
+    pub fn into_inner(self) -> i32 {
+        self.0
+    }
+
+    pub fn last_year() -> Self {
+        let offset = FixedOffset::east_opt(SERVER_UTC_OFFSET * 3600).unwrap();
+        let today = Utc::now().with_timezone(&offset);
+        if today.month() == 12 {
+            Self::__new_unchecked(today.year())
+        } else {
+            // December is not here yet, so last AoC was last year
+            Self::__new_unchecked(today.year() - 1)
+        }
+    }
+
+    /// Returns the current year.
+    pub fn this_year() -> Option<Self> {
+        let offset = FixedOffset::east_opt(SERVER_UTC_OFFSET * 3600)?;
+        let today = Utc::now().with_timezone(&offset);
+        Self::new(today.year())
+    }
+}
+
+impl Display for Year {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:04}", self.0)
+    }
+}
+
+impl PartialEq<i32> for Year {
+    fn eq(&self, other: &i32) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<i32> for Year {
+    fn partial_cmp(&self, other: &i32) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+
+impl FromStr for Year {
+    type Err = YearFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let year = s.parse().map_err(|_| YearFromStrError)?;
+        Self::new(year).ok_or(YearFromStrError)
+    }
+}
+
+/// An error which can be returned when parsing a [`year`].
+#[derive(Debug)]
+pub struct YearFromStrError;
+
+impl Error for YearFromStrError {}
+
+impl Display for YearFromStrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            format!(
+                "expecting a year number between 2015 and {}",
+                Year::last_year()
+            )
+            .as_str(),
+        )
+    }
+}


### PR DESCRIPTION
🎄 Hello ! Thank you for this great tool !

I am personally interested for multi year support (sharing libraries between years, all in one repo) and I saw in #22 that I am not the only one to want this feature.

I found a way to deal with that, by storing other years files apart from the runner and implement a new command (`cargo switch-year <Year>`) to move these files. Multi-year benchmarks is supported (the one shown in the readme is the year that is currently set up by the user). However multi year star tracking is not supported.

I tried to produce the cleanest code, but I know this system is not very satisfying as moving and managing folders is rather a workaround than a clean and safe solution. Still, I am happy with what I made and I will use it personally.

So this PR is a proof of concept, it's up to you to decide if you want to accept it (with reworks and improvement if needed, I may have forgotten compatibility issues with some features) or if you don't plan to make anything of this.

> `cargo fmt` and `clippy` were done.

Would fix #22